### PR TITLE
Calendars and Percentages

### DIFF
--- a/src/net/sf/mpxj/primavera/PrimaveraPMFileReader.java
+++ b/src/net/sf/mpxj/primavera/PrimaveraPMFileReader.java
@@ -328,6 +328,7 @@ public final class PrimaveraPMFileReader extends AbstractProjectReader
          resource.setNotes(xml.getResourceNotes());
          resource.setCreationDate(xml.getCreateDate());
          resource.setType(RESOURCE_TYPE_MAP.get(xml.getResourceType()));
+         resource.setMaxUnits(reversePercentage(xml.getMaxUnitsPerTime()));
 
          Integer calendarID = xml.getCalendarObjectId();
          if (calendarID != null)
@@ -460,7 +461,7 @@ public final class PrimaveraPMFileReader extends AbstractProjectReader
          }
 
          task.setUniqueID(uniqueID);
-         task.setPercentageComplete(NumberHelper.getDouble(row.getPercentComplete().doubleValue() * 100.0));
+         task.setPercentageComplete(reversePercentage(row.getPercentComplete()));
          task.setName(row.getName());
          task.setRemainingDuration(getDuration(row.getRemainingDuration()));
          task.setActualWork(getDuration(row.getActualDuration()));
@@ -641,6 +642,15 @@ public final class PrimaveraPMFileReader extends AbstractProjectReader
 
       return result;
    }
+
+   /** Reverse the effects of PrimaveraPMFileWriter.getPercentage(). */
+   private Number reversePercentage(Double n)
+   {
+      if (n == null)
+         return null;
+      return NumberHelper.getDouble(n.doubleValue() * 100.0);
+   }
+
    /**
     * Cached context to minimise construction cost.
     */

--- a/src/net/sf/mpxj/primavera/PrimaveraPMFileWriter.java
+++ b/src/net/sf/mpxj/primavera/PrimaveraPMFileWriter.java
@@ -271,15 +271,18 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
       HolidayOrExceptions xmlExceptions = m_factory.createCalendarTypeHolidayOrExceptions();
       xml.setHolidayOrExceptions(xmlExceptions);
 
+      if (mpxj.getCalendarExceptions().isEmpty())
+         return;
+      Calendar cal = Calendar.getInstance(); // Replaced m_calendar with local calendar instance because getEndTime() calls were using m_calendar.setTime() as well, wrecking the while loop conditional.
       for (ProjectCalendarException mpxjException : mpxj.getCalendarExceptions())
       {
-         m_calendar.setTime(mpxjException.getFromDate());
-         while (m_calendar.getTimeInMillis() < mpxjException.getToDate().getTime())
+         cal.setTime(mpxjException.getFromDate());
+         while (cal.getTimeInMillis() < mpxjException.getToDate().getTime())
          {
             HolidayOrException xmlException = m_factory.createCalendarTypeHolidayOrExceptionsHolidayOrException();
             xmlExceptions.getHolidayOrException().add(xmlException);
 
-            xmlException.setDate(m_calendar.getTime());
+            xmlException.setDate(cal.getTime());
 
             for (DateRange range : mpxjException)
             {
@@ -289,7 +292,7 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
                xmlHours.setStart(range.getStart());
                xmlHours.setFinish(getEndTime(range.getEnd()));
             }
-            m_calendar.add(Calendar.DAY_OF_YEAR, 1);
+            cal.add(Calendar.DAY_OF_YEAR, 1);
          }
       }
    }
@@ -436,6 +439,7 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
       xml.setId(mpxj.getWBS());
       xml.setName(mpxj.getName());
       xml.setObjectId(mpxj.getUniqueID());
+      xml.setPercentComplete(getPercentage(mpxj.getPercentageComplete()));
       xml.setPrimaryConstraintType(CONSTRAINT_TYPE_MAP.get(mpxj.getConstraintType()));
       xml.setPrimaryConstraintDate(mpxj.getConstraintDate());
       xml.setPlannedDuration(getDuration(mpxj.getDuration()));
@@ -490,11 +494,13 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
       Integer parentTaskUniqueID = parentTask == null ? null : parentTask.getUniqueID();
 
       xml.setActivityObjectId(mpxj.getTaskUniqueID());
+      xml.setActualCost(Double.valueOf(mpxj.getActualCost().doubleValue()));
       xml.setActualFinishDate(mpxj.getActualFinish());
       xml.setActualRegularUnits(getDuration(mpxj.getActualWork()));
       xml.setActualStartDate(mpxj.getActualStart());
       xml.setActualUnits(getDuration(mpxj.getActualWork()));
       xml.setAtCompletionUnits(getDuration(mpxj.getRemainingWork()));
+      xml.setPlannedCost(Double.valueOf(mpxj.getActualCost().doubleValue()));
       xml.setFinishDate(mpxj.getFinish());
       xml.setGUID(getGUID(mpxj.getGUID()));
       xml.setObjectId(mpxj.getUniqueID());
@@ -504,6 +510,7 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
       xml.setPlannedUnits(getDuration(mpxj.getWork()));
       xml.setPlannedUnitsPerTime(getPercentage(mpxj.getUnits()));
       xml.setProjectObjectId(PROJECT_OBJECT_ID);
+      xml.setRemainingCost(Double.valueOf(mpxj.getActualCost().doubleValue()));
       xml.setRemainingDuration(getDuration(mpxj.getRemainingWork()));
       xml.setRemainingFinishDate(mpxj.getFinish());
       xml.setRemainingStartDate(mpxj.getStart());


### PR DESCRIPTION
A couple of bug fixes.
A certain issue popped up that caused an infinite loop when exporting calendar exceptions.
Reverting percentages could result in NullPointerException if field doesn't exist in XML, because getPercentComplete() would return null.