### PR TITLE
Fix to infinite loop condition when writing calendar

### DIFF
--- a/src/net/sf/mpxj/primavera/PrimaveraPMFileWriter.java
+++ b/src/net/sf/mpxj/primavera/PrimaveraPMFileWriter.java
@@ -271,15 +271,18 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
       HolidayOrExceptions xmlExceptions = m_factory.createCalendarTypeHolidayOrExceptions();
       xml.setHolidayOrExceptions(xmlExceptions);
 
+      if (mpxj.getCalendarExceptions().isEmpty())
+         return;
+      Calendar cal = Calendar.getInstance();
       for (ProjectCalendarException mpxjException : mpxj.getCalendarExceptions())
       {
-         m_calendar.setTime(mpxjException.getFromDate());
-         while (m_calendar.getTimeInMillis() < mpxjException.getToDate().getTime())
+         cal.setTime(mpxjException.getFromDate());
+         while (cal.getTimeInMillis() < mpxjException.getToDate().getTime())
          {
             HolidayOrException xmlException = m_factory.createCalendarTypeHolidayOrExceptionsHolidayOrException();
             xmlExceptions.getHolidayOrException().add(xmlException);
 
-            xmlException.setDate(m_calendar.getTime());
+            xmlException.setDate(cal.getTime());
 
             for (DateRange range : mpxjException)
             {
@@ -289,7 +292,7 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
                xmlHours.setStart(range.getStart());
                xmlHours.setFinish(getEndTime(range.getEnd()));
             }
-            m_calendar.add(Calendar.DAY_OF_YEAR, 1);
+            cal.add(Calendar.DAY_OF_YEAR, 1);
          }
       }
    }


### PR DESCRIPTION
There was a problem where a call to getEndTime() would call
m_calendar.setTime(), when this call happened in the while loop as well.
Because the loop terminal condition called m_calendar.getTimeInMillis(),
if the last range.getEnd() is some date more than a day before
mpxjException.getToDate(), then the loop would never terminate. This is
fixed by creating a new calendar instance in the scope of the loop so
that m_calendar isn't being used in the terminal condition when it can
accidentally be set in a getter method.