### PR TITLE
Symmetry between Primavera PM reader/writer

### DIFF
--- a/src/net/sf/mpxj/primavera/PrimaveraPMFileReader.java
+++ b/src/net/sf/mpxj/primavera/PrimaveraPMFileReader.java
@@ -328,6 +328,7 @@ public final class PrimaveraPMFileReader extends AbstractProjectReader
          resource.setNotes(xml.getResourceNotes());
          resource.setCreationDate(xml.getCreateDate());
          resource.setType(RESOURCE_TYPE_MAP.get(xml.getResourceType()));
+         resource.setMaxUnits(reversePercentage(xml.getMaxUnitsPerTime()));
 
          Integer calendarID = xml.getCalendarObjectId();
          if (calendarID != null)
@@ -460,7 +461,7 @@ public final class PrimaveraPMFileReader extends AbstractProjectReader
          }
 
          task.setUniqueID(uniqueID);
-         task.setPercentageComplete(NumberHelper.getDouble(row.getPercentComplete().doubleValue() * 100.0));
+         task.setPercentageComplete(reversePercentage(row.getPercentComplete()));
          task.setName(row.getName());
          task.setRemainingDuration(getDuration(row.getRemainingDuration()));
          task.setActualWork(getDuration(row.getActualDuration()));
@@ -641,6 +642,15 @@ public final class PrimaveraPMFileReader extends AbstractProjectReader
 
       return result;
    }
+
+   /** Reverse the effects of PrimaveraPMFileWriter.getPercentage(). */
+   private Number reversePercentage(Double n)
+   {
+      if (n == null)
+         return null;
+      return NumberHelper.getDouble(n.doubleValue() * 100.0);
+   }
+
    /**
     * Cached context to minimise construction cost.
     */

--- a/src/net/sf/mpxj/primavera/PrimaveraPMFileWriter.java
+++ b/src/net/sf/mpxj/primavera/PrimaveraPMFileWriter.java
@@ -436,6 +436,7 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
       xml.setId(mpxj.getWBS());
       xml.setName(mpxj.getName());
       xml.setObjectId(mpxj.getUniqueID());
+      xml.setPercentComplete(getPercentage(mpxj.getPercentageComplete()));
       xml.setPrimaryConstraintType(CONSTRAINT_TYPE_MAP.get(mpxj.getConstraintType()));
       xml.setPrimaryConstraintDate(mpxj.getConstraintDate());
       xml.setPlannedDuration(getDuration(mpxj.getDuration()));
@@ -490,11 +491,13 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
       Integer parentTaskUniqueID = parentTask == null ? null : parentTask.getUniqueID();
 
       xml.setActivityObjectId(mpxj.getTaskUniqueID());
+      xml.setActualCost(Double.valueOf(mpxj.getActualCost().doubleValue()));
       xml.setActualFinishDate(mpxj.getActualFinish());
       xml.setActualRegularUnits(getDuration(mpxj.getActualWork()));
       xml.setActualStartDate(mpxj.getActualStart());
       xml.setActualUnits(getDuration(mpxj.getActualWork()));
       xml.setAtCompletionUnits(getDuration(mpxj.getRemainingWork()));
+      xml.setPlannedCost(Double.valueOf(mpxj.getActualCost().doubleValue()));
       xml.setFinishDate(mpxj.getFinish());
       xml.setGUID(getGUID(mpxj.getGUID()));
       xml.setObjectId(mpxj.getUniqueID());
@@ -504,6 +507,7 @@ public final class PrimaveraPMFileWriter extends AbstractProjectWriter
       xml.setPlannedUnits(getDuration(mpxj.getWork()));
       xml.setPlannedUnitsPerTime(getPercentage(mpxj.getUnits()));
       xml.setProjectObjectId(PROJECT_OBJECT_ID);
+      xml.setRemainingCost(Double.valueOf(mpxj.getActualCost().doubleValue()));
       xml.setRemainingDuration(getDuration(mpxj.getRemainingWork()));
       xml.setRemainingFinishDate(mpxj.getFinish());
       xml.setRemainingStartDate(mpxj.getStart());


### PR DESCRIPTION
Introduced method reversePercentage() in the reader, the functional
inverse of getPercentage() in the writer, including null handling, which
wasn't in the reader before; calling
row.getPercentComplete().doubleValue() would result in a
NullPointerException if the xml didn't contain the field number. In
addition, resource costs added in the writer to match the section in the
reader which looks for these fields.