### PR TITLE
UDF support for Primavera PM format

### DIFF
--- a/src/net/sf/mpxj/CustomFieldContainer.java
+++ b/src/net/sf/mpxj/CustomFieldContainer.java
@@ -73,7 +73,7 @@ public class CustomFieldContainer implements Iterable<CustomField>
     * 
     * @param item custom field value
     */
-   void registerValue(CustomFieldValueItem item)
+   public void registerValue(CustomFieldValueItem item)
    {
       m_valueMap.put(item.getUniqueID(), item);
    }
@@ -83,7 +83,7 @@ public class CustomFieldContainer implements Iterable<CustomField>
     * 
     * @param item custom field value
     */
-   void deregisterValue(CustomFieldValueItem item)
+   public void deregisterValue(CustomFieldValueItem item)
    {
       m_valueMap.remove(item.getUniqueID());
    }
@@ -111,7 +111,38 @@ public class CustomFieldContainer implements Iterable<CustomField>
       return m_aliasMap.get(new Pair<FieldTypeClass, String>(typeClass, alias));
    }
 
+   /**
+    * Because there seemingly is no deterministic method of mapping UDF ObjectIds from Primavera PM to FieldTypes,
+    * the aliasValueMap will store UDF values to be used by something that knows what alias maps to which FieldType.
+    * @author lsong
+    * @param alias custom field alias
+    * @param uid field container unique id
+    * @param value field value
+    */
+   public void registerAliasValue(String alias, Integer uid, Object value)
+   {
+      if (!m_aliasValueMap.containsKey(alias))
+         m_aliasValueMap.put(alias, new HashMap<Integer, Object>());
+      m_aliasValueMap.get(alias).put(uid, value);
+   }
+
+   /**
+    * Importers with access to the ProjectFile containing this can determine how to
+    * use the values in the UDFAssignmentTypes in UDF containers.
+    * @author lsong
+    * @param alias custom field alias
+    * @param uid field container unique id
+    * @return field value
+    */
+   public Object getAliasValue(String alias, Integer uid)
+   {
+      if (m_aliasValueMap.containsKey(alias))
+         return m_aliasValueMap.get(alias).get(uid);
+      return null;
+   }
+
    private Map<FieldType, CustomField> m_configMap = new HashMap<FieldType, CustomField>();
    private Map<Integer, CustomFieldValueItem> m_valueMap = new HashMap<Integer, CustomFieldValueItem>();
    private Map<Pair<FieldTypeClass, String>, FieldType> m_aliasMap = new HashMap<Pair<FieldTypeClass, String>, FieldType>();
+   private Map<String, Map<Integer, Object>> m_aliasValueMap = new HashMap<String, Map<Integer, Object>>();
 }

--- a/src/net/sf/mpxj/primavera/UserFieldDataType.java
+++ b/src/net/sf/mpxj/primavera/UserFieldDataType.java
@@ -23,6 +23,14 @@
 
 package net.sf.mpxj.primavera;
 
+import net.sf.mpxj.AssignmentField;
+import net.sf.mpxj.ConstraintField;
+import net.sf.mpxj.DataType;
+import net.sf.mpxj.FieldType;
+import net.sf.mpxj.ProjectField;
+import net.sf.mpxj.ResourceField;
+import net.sf.mpxj.TaskField;
+
 /**
  * User defined field data types. 
  */
@@ -55,6 +63,49 @@ public enum UserFieldDataType
    public String getDefaultFieldName()
    {
       return m_defaultFieldName;
+   }
+
+   /**
+    * @author kmahan 
+    * @date 2014-09-24
+    * @return string representation of data type
+    */
+   public static String inferUserFieldDataType(DataType dataType)
+   {
+      switch (dataType)
+      {
+         case STRING:
+            return "Text";
+         case DATE:
+            return "Start Date";
+         case NUMERIC:
+            return "Double";
+         case INTEGER:
+         case SHORT:
+            return "Integer";
+         default:
+            throw new RuntimeException("Unconvertible data type: " + dataType);
+      }
+   }
+
+   /**
+    * @author lsong
+    * @date 2015-7-24
+    * @return udf subject area
+    */
+   public static String inferUserFieldSubjectArea(FieldType fieldType)
+   {
+      if (fieldType instanceof TaskField)
+         return "Activity";
+      if (fieldType instanceof ResourceField)
+         return "Resource";
+      if (fieldType instanceof ProjectField)
+         return "Project";
+      if (fieldType instanceof AssignmentField)
+         return "Assignment";
+      if (fieldType instanceof ConstraintField)
+         return "Constraint";
+      throw new RuntimeException("Unrecognized field type: " + fieldType);
    }
 
    private String m_defaultFieldName;

--- a/src/net/sf/mpxj/primavera/schema/UDFAssignmentType.java
+++ b/src/net/sf/mpxj/primavera/schema/UDFAssignmentType.java
@@ -8,12 +8,16 @@
 package net.sf.mpxj.primavera.schema;
 
 import java.util.Date;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlSchemaType;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import net.sf.mpxj.DataType;
+import net.sf.mpxj.common.NumberHelper;
 
 /**
  * <p>Java class for UDFAssignmentType complex type.
@@ -302,4 +306,34 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
       this.finishDateValue = value;
    }
 
+   /**
+    * @author kmahan
+    */
+   public static void setUserFieldValue(UDFAssignmentType udf, DataType dataType, Object value)
+   {
+      switch (dataType)
+      {
+         case STRING:
+            // write empty string instead of null to make sure we get a value
+            // node in the XML output
+            udf.setTextValue(value != null ? (String) value : "");
+            break;
+         case DATE:
+            udf.setStartDateValue((Date) value);
+            break;
+         case NUMERIC:
+            if (value != null && !(value instanceof Double))
+            {
+               value = Double.valueOf(((Number) value).doubleValue());
+            }
+            udf.setDoubleValue((Double) value);
+            break;
+         case INTEGER:
+         case SHORT:
+            udf.setIntegerValue(NumberHelper.getInteger((Number) value));
+            break;
+         default:
+            throw new RuntimeException("Unconvertible data type: " + dataType);
+      }
+   }
 }


### PR DESCRIPTION
Added custom field support using existing custom field classes, as well
as some modifications. One big modification is the handling of UDFs in
the reader; because there is no deterministic way to map the object IDs
of the user fields that Primavera exports to FieldTypes in field
containers, the UDF data is simply left as raw data in the
CustomFieldContainer accessible from the ProjectFile returned by the
reader.