### PR TITLE
Update pom.xml to fix incorrect license id

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -187,8 +187,8 @@
 
 	<licenses>
 		<license>
-			<name>GNU Lesser General Public License v3.0 or later</name>
-			<url>http://www.gnu.org/licenses/lgpl-3.0-standalone.html</url>
+			<name>GNU Lesser General Public License v2.1 or later</name>
+			<url>https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html</url>
 		</license>
 	</licenses>
 


### PR DESCRIPTION
The project LICENSE file is LGPL-2.1 and the license headers on the *.java source files are LGPL-2.1.
This fixes https://github.com/joniles/mpxj/issues/53