### PR TITLE
Outofsequence fields and schedoptions

### DIFF
--- a/src/net/sf/mpxj/LocaleData.java
+++ b/src/net/sf/mpxj/LocaleData.java
@@ -104,6 +104,8 @@ public final class LocaleData extends ListResourceBundle
       TASK_COLUMNS_ARRAY[TaskField.FINISH.getValue()] = "Finish";
       TASK_COLUMNS_ARRAY[TaskField.EARLY_START.getValue()] = "Early Start";
       TASK_COLUMNS_ARRAY[TaskField.EARLY_FINISH.getValue()] = "Early Finish";
+      TASK_COLUMNS_ARRAY[TaskField.REMAINING_EARLY_START.getValue()] = "Remaining Early Start";
+      TASK_COLUMNS_ARRAY[TaskField.REMAINING_EARLY_FINISH.getValue()] = "Remaining Early Finish";
       TASK_COLUMNS_ARRAY[TaskField.LATE_START.getValue()] = "Late Start";
       TASK_COLUMNS_ARRAY[TaskField.LATE_FINISH.getValue()] = "Late Finish";
       TASK_COLUMNS_ARRAY[TaskField.ACTUAL_START.getValue()] = "Actual Start";

--- a/src/net/sf/mpxj/Task.java
+++ b/src/net/sf/mpxj/Task.java
@@ -962,6 +962,16 @@ public final class Task extends ProjectEntity implements Comparable<Task>, Proje
    }
 
    /**
+   * The date the resource is scheduled to finish the remaining work for the activity.
+   *
+   * @param date Date value
+   */
+   public void setRemainingEarlyFinish(Date date)
+   {
+      set(TaskField.REMAINING_EARLY_FINISH, date);
+   }
+
+   /**
     * The Early Start field contains the earliest date that a task could
     * possibly begin, based on the early start dates of predecessor and
     * successor tasks, and other constraints.
@@ -971,6 +981,16 @@ public final class Task extends ProjectEntity implements Comparable<Task>, Proje
    public void setEarlyStart(Date date)
    {
       set(TaskField.EARLY_START, date);
+   }
+
+   /**
+   * The date the resource is scheduled to begin the remaining work for the activity.
+   *
+   * @param date Date value
+   */
+   public void setRemainingEarlyStart(Date date)
+   {
+      set(TaskField.REMAINING_EARLY_START, date);
    }
 
    /**
@@ -1984,6 +2004,16 @@ public final class Task extends ProjectEntity implements Comparable<Task>, Proje
    }
 
    /**
+   * The date the resource is scheduled to finish the remaining work for the activity.
+   *
+   * @return Date
+   */
+   public Date getRemainingEarlyFinish()
+   {
+      return ((Date) getCachedValue(TaskField.REMAINING_EARLY_FINISH));
+   }
+
+   /**
     * The Early Start field contains the earliest date that a task could
     * possibly begin, based on the early start dates of predecessor and
     * successor tasks, and other constraints.
@@ -1993,6 +2023,16 @@ public final class Task extends ProjectEntity implements Comparable<Task>, Proje
    public Date getEarlyStart()
    {
       return ((Date) getCachedValue(TaskField.EARLY_START));
+   }
+
+   /**
+   * The date the resource is scheduled to start the remaining work for the activity.
+   *
+   * @return Date
+   */
+   public Date getRemainingEarlyStart()
+   {
+      return ((Date) getCachedValue(TaskField.REMAINING_EARLY_START));
    }
 
    /**
@@ -2795,7 +2835,7 @@ public final class Task extends ProjectEntity implements Comparable<Task>, Proje
    /**
     * This method retrieves a flag indicating whether the duration of the
     * task has only been estimated.
-
+   
     * @param estimated Boolean flag
     */
    public void setEstimated(boolean estimated)

--- a/src/net/sf/mpxj/TaskField.java
+++ b/src/net/sf/mpxj/TaskField.java
@@ -83,6 +83,8 @@ public enum TaskField implements FieldType
    PERCENT_WORK_COMPLETE(DataType.PERCENTAGE),
    EARLY_START(DataType.DATE),
    EARLY_FINISH(DataType.DATE),
+   REMAINING_EARLY_START(DataType.DATE),
+   REMAINING_EARLY_FINISH(DataType.DATE),
    LATE_START(DataType.DATE),
    LATE_FINISH(DataType.DATE),
    ACTUAL_START(DataType.DATE),

--- a/src/net/sf/mpxj/primavera/PrimaveraReader.java
+++ b/src/net/sf/mpxj/primavera/PrimaveraReader.java
@@ -1064,6 +1064,8 @@ final class PrimaveraReader
          Date actualFinishDate = parentTask.getActualFinish();
          Date earlyStartDate = parentTask.getEarlyStart();
          Date earlyFinishDate = parentTask.getEarlyFinish();
+         Date remainingEarlyStartDate = parentTask.getEarlyStart();
+         Date remainingEarlyFinishDate = parentTask.getEarlyFinish();
          Date lateStartDate = parentTask.getLateStart();
          Date lateFinishDate = parentTask.getLateFinish();
          Date baselineStartDate = parentTask.getBaselineStart();
@@ -1082,6 +1084,8 @@ final class PrimaveraReader
             actualFinishDate = DateHelper.max(actualFinishDate, task.getActualFinish());
             earlyStartDate = DateHelper.min(earlyStartDate, task.getEarlyStart());
             earlyFinishDate = DateHelper.max(earlyFinishDate, task.getEarlyFinish());
+            remainingEarlyStartDate = DateHelper.min(remainingEarlyStartDate, task.getRemainingEarlyStart());
+            remainingEarlyFinishDate = DateHelper.max(remainingEarlyFinishDate, task.getRemainingEarlyFinish());
             lateStartDate = DateHelper.min(lateStartDate, task.getLateStart());
             lateFinishDate = DateHelper.max(lateFinishDate, task.getLateFinish());
             baselineStartDate = DateHelper.min(baselineStartDate, task.getBaselineStart());
@@ -1098,6 +1102,8 @@ final class PrimaveraReader
          parentTask.setActualStart(actualStartDate);
          parentTask.setEarlyStart(earlyStartDate);
          parentTask.setEarlyFinish(earlyFinishDate);
+         parentTask.setRemainingEarlyStart(remainingEarlyStartDate);
+         parentTask.setRemainingEarlyFinish(remainingEarlyFinishDate);
          parentTask.setLateStart(lateStartDate);
          parentTask.setLateFinish(lateFinishDate);
          parentTask.setBaselineStart(baselineStartDate);
@@ -1657,6 +1663,8 @@ final class PrimaveraReader
       map.put(TaskField.LATE_FINISH, "late_end_date");
       map.put(TaskField.EARLY_START, "early_start_date");
       map.put(TaskField.EARLY_FINISH, "early_end_date");
+      map.put(TaskField.REMAINING_EARLY_START, "restart_date");
+      map.put(TaskField.REMAINING_EARLY_FINISH, "reend_date");
       map.put(TaskField.BASELINE_START, "target_start_date");
       map.put(TaskField.BASELINE_FINISH, "target_end_date");
       map.put(TaskField.CONSTRAINT_TYPE, "cstr_type");

--- a/src/net/sf/mpxj/primavera/PrimaveraReader.java
+++ b/src/net/sf/mpxj/primavera/PrimaveraReader.java
@@ -1064,8 +1064,8 @@ final class PrimaveraReader
          Date actualFinishDate = parentTask.getActualFinish();
          Date earlyStartDate = parentTask.getEarlyStart();
          Date earlyFinishDate = parentTask.getEarlyFinish();
-         Date remainingEarlyStartDate = parentTask.getEarlyStart();
-         Date remainingEarlyFinishDate = parentTask.getEarlyFinish();
+         Date remainingEarlyStartDate = parentTask.getRemainingEarlyStart();
+         Date remainingEarlyFinishDate = parentTask.getRemainingEarlyFinish();
          Date lateStartDate = parentTask.getLateStart();
          Date lateFinishDate = parentTask.getLateFinish();
          Date baselineStartDate = parentTask.getBaselineStart();

--- a/src/net/sf/mpxj/primavera/PrimaveraXERFileReader.java
+++ b/src/net/sf/mpxj/primavera/PrimaveraXERFileReader.java
@@ -443,6 +443,8 @@ public final class PrimaveraXERFileReader extends AbstractProjectReader
          Row row = rows.get(0);
          Map<String, Object> customProperties = new HashMap<String, Object>();
          customProperties.put("LagCalendar", row.getString("sched_calendar_on_relationship_lag"));
+         customProperties.put("RetainedLogic", Boolean.valueOf(row.getBoolean("sched_retained_logic")));
+         customProperties.put("ProgressOverride", Boolean.valueOf(row.getBoolean("sched_progress_override")));
          m_reader.getProject().getProjectProperties().setCustomProperties(customProperties);
       }
    }


### PR DESCRIPTION
Explanation of additions:

2 new SchedOptions properties that are necessary for determining how to handle out of sequence relationships

Store Remaining Early Start and Remaining Early Finish as their own properties.  They are evaluated for setting Start already, but in the case of Out of Sequence = Retained Logic, the remaining dates are still required to determine proper handling (e.g., to calculate Relationship Free Float, restart_date is used instead of act_start_date.