### PR TITLE
Store 2 additional P6 schedule options

### DIFF
--- a/src/net/sf/mpxj/primavera/PrimaveraXERFileReader.java
+++ b/src/net/sf/mpxj/primavera/PrimaveraXERFileReader.java
@@ -445,6 +445,8 @@ public final class PrimaveraXERFileReader extends AbstractProjectReader
          customProperties.put("LagCalendar", row.getString("sched_calendar_on_relationship_lag"));
          customProperties.put("RetainedLogic", Boolean.valueOf(row.getBoolean("sched_retained_logic")));
          customProperties.put("ProgressOverride", Boolean.valueOf(row.getBoolean("sched_progress_override")));
+         customProperties.put("IgnoreOtherProjectRelationships", row.getString("sched_outer_depend_type"));
+         customProperties.put("StartToStartLagCalculationType", Boolean.valueOf(row.getBoolean("sched_lag_early_start_flag")));
          m_reader.getProject().getProjectProperties().setCustomProperties(customProperties);
       }
    }


### PR DESCRIPTION
Store 2 additional values for P6 SCHEDOPTIONS from XER files:
IgnoreOtherProjectRelationships (sched_outer_depend_type)
StartToStartLagCalculationType (sched_lag_early_start_flag)