### PR TITLE
Improvement for performance when reading files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,12 @@
 			<artifactId>rtfparserkit</artifactId>
 			<version>1.13.0</version>
 		</dependency>
+		
+		<dependency>
+            		<groupId>joda-time</groupId>
+            		<artifactId>joda-time</artifactId>
+            		<version>2.10.1</version>
+        	</dependency>
 
 		<!-- Test dependencies -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,10 @@
 		</dependency>
 		
 		<dependency>
-            		<groupId>joda-time</groupId>
-            		<artifactId>joda-time</artifactId>
-            		<version>2.10.1</version>
-        	</dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.10.1</version>
+		</dependency>
 
 		<!-- Test dependencies -->
 		<dependency>
@@ -204,6 +204,9 @@
 		</contributor>
 		<contributor>
 			<name>Elio Zoggia</name>
+		</contributor>
+		<contributor>
+			<name>Tiago de Mello</name>
 		</contributor>
 	</contributors>
 

--- a/src/main/java/net/sf/mpxj/common/DateHelper.java
+++ b/src/main/java/net/sf/mpxj/common/DateHelper.java
@@ -27,6 +27,8 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
+import org.joda.time.LocalDate;
+
 import net.sf.mpxj.Duration;
 import net.sf.mpxj.ProjectCalendar;
 import net.sf.mpxj.Task;
@@ -56,13 +58,7 @@ public final class DateHelper
    {
       if (date != null)
       {
-         Calendar cal = Calendar.getInstance();
-         cal.setTime(date);
-         cal.set(Calendar.HOUR_OF_DAY, 0);
-         cal.set(Calendar.MINUTE, 0);
-         cal.set(Calendar.SECOND, 0);
-         cal.set(Calendar.MILLISECOND, 0);
-         date = cal.getTime();
+         date = new LocalDate(date).toDate();
       }
       return (date);
    }


### PR DESCRIPTION
It was a small change in the DateHelper changing the Calendar for the new lib JodaTime with do not use machine resources that is used for new Calendar instances.
In manual tests a reading operation with a huge file that used to takes 10 minutes started to take 30 seconds after the change.
The change was done only in the most used method that was responsable for the most of waiting time.
