### PR TITLE
export "levelingDelayUnits" and "actualDurationUnits" when read from MSPDI

### DIFF
--- a/src/main/java/net/sf/mpxj/Task.java
+++ b/src/main/java/net/sf/mpxj/Task.java
@@ -3139,7 +3139,28 @@ public final class Task extends ProjectEntity implements Comparable<Task>, Proje
     */
    public TimeUnit getLevelingDelayFormat()
    {
-      return (m_levelingDelayFormat);
+      Object result = m_levelingDelayFormat;
+
+      if(result == null)
+      {
+         result = getCachedValue(TaskField.LEVELING_DELAY_UNITS);
+
+         if (result == null)
+         {
+            final Duration duration = getLevelingDelay();
+            if (duration != null)
+            {
+               result = duration.getUnits();
+            }
+         }
+      }
+
+      if (!(result instanceof TimeUnit))
+      {
+         result = null;
+      }
+
+      return (TimeUnit)result;
    }
 
    /**
@@ -4773,6 +4794,18 @@ public final class Task extends ProjectEntity implements Comparable<Task>, Proje
                break;
             }
 
+            case ACTUAL_DURATION_UNITS:
+            {
+               result = getActualDurationsFormat();
+               break;
+            }
+
+            case LEVELING_DELAY_UNITS:
+            {
+               result = getLevelingDelayFormat();
+               break;
+            }
+
             default:
             {
                result = m_array[field.getValue()];
@@ -4798,6 +4831,32 @@ public final class Task extends ProjectEntity implements Comparable<Task>, Proje
          }
          m_array[index] = value;
       }
+   }
+
+   /**
+    * Retrieve the actual duration format.
+    *
+    * @return actual duration format
+    */
+   private TimeUnit getActualDurationsFormat()
+   {
+      Object result = getCachedValue(TaskField.ACTUAL_DURATION_UNITS);
+
+      if(result == null)
+      {
+         final Duration duration = getActualDuration();
+         if(duration != null)
+         {
+            result = duration.getUnits();
+         }
+      }
+
+      if (!(result instanceof TimeUnit))
+      {
+         result = null;
+      }
+
+      return (TimeUnit)result;
    }
 
    /**


### PR DESCRIPTION
# Problem
The following `net.sf.mpxj.Task` fields are not exported (using `net.sf.mpxj.json.JsonWriter`) after reading it from an MSPDI file:

- `TaskField.ACTUAL_DURATION_UNITS`
- `TaskField.LEVELING_DELAY_UNITS`

However, these fields are correctly exported, if the same Microsoft Project were imported as an MPP file.

The reason for this deviant behavior are the ways how the `Task` fields/properties are set.

The `net.sf.mpxj.mspdi.MSPDIReader` uses the [setters](https://github.com/joniles/mpxj/blob/1eb3b5a35460a3bd76f1ee64a9a3b6a08e9f1e7a/src/main/java/net/sf/mpxj/mspdi/MSPDIReader.java#L1150) of the `Task` class. And some of these setters store the value in an internal property instead of the internal fields array.

The `net.sf.mpxj.mpp.MPP14Reader` instead uses the [fieldMap.populateContainer](https://github.com/joniles/mpxj/blob/1eb3b5a35460a3bd76f1ee64a9a3b6a08e9f1e7a/src/main/java/net/sf/mpxj/mpp/MPP14Reader.java#L1079) to set these values.
In that case the values are stored in the internal fields array.

To fetch the task field values during the export, the `net.sf.mpxj.json.JsonWriter` calls the [net.sf.mpxj.Task::getCurrentValue](https://github.com/joniles/mpxj/blob/143ea0e195da59cd108f13b3b06328e9542337e8/src/main/java/net/sf/mpxj/Task.java#L4690).
In case of the fields `TaskField.ACTUAL_DURATION_UNITS` and `TaskField.LEVELING_DELAY_UNITS` these values are searched in the internal fields array. But the `net.sf.mpxj.mspdi.MSPDIReader` stored
these values in internal properties of the `Task` class, therefore these values can't be read from the internal fields array.


# Solution
I tried to fix this problem, but I'm unsure if my expectations are right.

For `TaskField.ACTUAL_DURATION_UNITS` I expect:
 * `task.getActualDuration().getUnits()` is the same as `task.getCachedValue(TaskField.ACTUAL_DURATION_UNITS)`


For `TaskField.LEVELING_DELAY_UNITS` I expect:
 * `task.getLevelingDelay().getUnits()` is the same as `task.getLevelingDelayFormat()`
 * `task.getLevelingDelayFormat()` is the same as `task.getCachedValue(TaskField.LEVELING_DELAY_UNITS)`

If this expectation is correct, then there exist multiple properties in the `Task` class to store the same information.

To stay as backward compatible as possible, I didn't modified the existing ways to set these values.
The modified/added methods `Task::getLevelingDelayFormat` and `Task::getActualDurationsFormat` include a fall back to return the expected value, regardless which way was used to store these values.

Let me know if my expectation isn't correct and I will update the solution.


