### PR TITLE
StreamHelper.skip can enter an infinite loop

### DIFF
--- a/src/main/java/net/sf/mpxj/common/StreamHelper.java
+++ b/src/main/java/net/sf/mpxj/common/StreamHelper.java
@@ -43,7 +43,9 @@ public final class StreamHelper
       long count = skip;
       while (count > 0)
       {
-         count -= stream.skip(count);
+         long skipped = stream.skip(count);
+         if (skipped == 0) throw new IOException("Cannot skip forward within InputStream");
+         count -= skipped;
       }
    }
 


### PR DESCRIPTION
StreamHelper.skip can enter an infinite loop if it encounters the EOF during the skip request.

This was occurring when opening a corrupt MPP file however corrupt files at runtime should cause an IOException not an infinite loop.


The infinite loop (from a corrupt MPP plan) that I observed had this trace:

Thread [main] (Suspended)	
	NDocumentInputStream(DocumentInputStream).readFully(byte[]) line: 162	
	NDocumentInputStream.skip(long) line: 228	
	DocumentInputStream.skip(long) line: 142	
	StreamHelper.skip(InputStream, long) line: 46	
	Var2Data.<init>(VarMeta, InputStream) line: 78	
	MPP12Reader.processTaskData() line: 946	
	MPP12Reader.process(MPPReader, ProjectFile, DirectoryEntry) line: 88	
	MPPReader.read(POIFSFileSystem) line: 158	
	MPPReader.read(InputStream) line: 80	
	MPPReader(AbstractProjectReader).read(File) line: 77	
	TestMPXJ.main(String[]) line: 12	
