### PR TITLE
Set RT_Equip to COST instead of WORK

### DIFF
--- a/src/main/java/net/sf/mpxj/primavera/PrimaveraReader.java
+++ b/src/main/java/net/sf/mpxj/primavera/PrimaveraReader.java
@@ -1757,7 +1757,7 @@ final class PrimaveraReader
       RESOURCE_TYPE_MAP.put(null, ResourceType.WORK);
       RESOURCE_TYPE_MAP.put("RT_Labor", ResourceType.WORK);
       RESOURCE_TYPE_MAP.put("RT_Mat", ResourceType.MATERIAL);
-      RESOURCE_TYPE_MAP.put("RT_Equip", ResourceType.WORK);
+      RESOURCE_TYPE_MAP.put("RT_Equip", ResourceType.COST);
    }
 
    private static final Map<String, ConstraintType> CONSTRAINT_TYPE_MAP = new HashMap<String, ConstraintType>();


### PR DESCRIPTION
I changed this a while ago on my fork, but forgot to PR it.
I'm not totally sure how this affects users of this enum elsewhere in the code; however, for me it was necessary to differentiate rt_equip from rt_labor.

This appears to be how P6 defines it:

RT_Labor | Labor
RT_Equip | Nonlabor
RT_Mat | Material

