### PR TITLE
Add flag to ignore passwords

### DIFF
--- a/src/main/java/net/sf/mpxj/ProjectField.java
+++ b/src/main/java/net/sf/mpxj/ProjectField.java
@@ -159,6 +159,8 @@ public enum ProjectField implements FieldType
    FILE_APPLICATION(DataType.STRING),
    FILE_TYPE(DataType.STRING),
    EXPORT_FLAG(DataType.BOOLEAN),
+   READ_ENCRYPTED(DataType.BOOLEAN),
+   WRITE_ENCRYPTED(DataType.BOOLEAN),
 
    FINISH_DATE(DataType.DATE); // Must always be last value
 

--- a/src/main/java/net/sf/mpxj/ProjectProperties.java
+++ b/src/main/java/net/sf/mpxj/ProjectProperties.java
@@ -2641,6 +2641,32 @@ public final class ProjectProperties extends ProjectEntity implements FieldConta
       set(ProjectField.EXPORT_FLAG, value);
    }
 
+   public void setReadEncrypted(boolean value) {
+       set(ProjectField.READ_ENCRYPTED, value);
+   }
+
+   /**
+    * Is this project file read-encrypted?
+    *
+    * @return value boolean flag
+    */
+   public boolean getReadEncrypted() {
+       return BooleanHelper.getBoolean((Boolean) getCachedValue(ProjectField.READ_ENCRYPTED));
+   }
+
+   public void setWriteEncrypted(boolean value) {
+       set(ProjectField.WRITE_ENCRYPTED, value);
+   }
+
+   /**
+    * Is this project file write-encrypted?
+    *
+    * @return value boolean flag
+    */
+   public boolean getWriteEncrypted() {
+       return BooleanHelper.getBoolean((Boolean) getCachedValue(ProjectField.WRITE_ENCRYPTED));
+   }
+
    /**
     * {@inheritDoc}
     */

--- a/src/main/java/net/sf/mpxj/mpp/MPP12Reader.java
+++ b/src/main/java/net/sf/mpxj/mpp/MPP12Reader.java
@@ -139,8 +139,10 @@ final class MPP12Reader implements MPPVariantReader
       // 0x01 = protection password has been supplied
       // 0x02 = write reservation password has been supplied
       // 0x03 = both passwords have been supplied
-      //
-      if (! reader.getIgnorePassword() && (props12.getByte(Props.PASSWORD_FLAG) & 0x01) != 0)
+      byte encryption = props12.getByte(Props.PASSWORD_FLAG);
+      boolean readEncrypted = (encryption & 0x1) != 0;
+      boolean writeEncrypted = (encryption & 0x2) != 0;
+      if (! reader.getIgnorePassword() && readEncrypted)
       {
          // Couldn't figure out how to get the password for MPP12 files so for now we just need to block the reading
          throw new MPXJException(MPXJException.PASSWORD_PROTECTED);
@@ -167,6 +169,8 @@ final class MPP12Reader implements MPPVariantReader
 
       m_file.getProjectProperties().setMppFileType(Integer.valueOf(12));
       m_file.getProjectProperties().setAutoFilter(props12.getBoolean(Props.AUTO_FILTER));
+      m_file.getProjectProperties().setReadEncrypted(readEncrypted);
+      m_file.getProjectProperties().setWriteEncrypted(writeEncrypted);
 
    }
 

--- a/src/main/java/net/sf/mpxj/mpp/MPP12Reader.java
+++ b/src/main/java/net/sf/mpxj/mpp/MPP12Reader.java
@@ -140,7 +140,7 @@ final class MPP12Reader implements MPPVariantReader
       // 0x02 = write reservation password has been supplied
       // 0x03 = both passwords have been supplied
       //
-      if ((props12.getByte(Props.PASSWORD_FLAG) & 0x01) != 0)
+      if (! reader.getIgnorePassword() && (props12.getByte(Props.PASSWORD_FLAG) & 0x01) != 0)
       {
          // Couldn't figure out how to get the password for MPP12 files so for now we just need to block the reading
          throw new MPXJException(MPXJException.PASSWORD_PROTECTED);
@@ -1284,7 +1284,7 @@ final class MPP12Reader implements MPPVariantReader
       // Renumber ID values using a large increment to allow
       // space for later inserts.
       //
-      TreeMap<Integer, Integer> taskMap = new TreeMap<Integer, Integer>();     
+      TreeMap<Integer, Integer> taskMap = new TreeMap<Integer, Integer>();
       int nextIDIncrement = ((m_nullTaskOrder.size() / 1000) + 1) * 1000;
       int nextID = (m_file.getTaskByUniqueID(Integer.valueOf(0)) == null ? nextIDIncrement : 0);
       for (Map.Entry<Long, Integer> entry : m_taskOrder.entrySet())

--- a/src/main/java/net/sf/mpxj/mpp/MPP14Reader.java
+++ b/src/main/java/net/sf/mpxj/mpp/MPP14Reader.java
@@ -95,7 +95,7 @@ final class MPP14Reader implements MPPVariantReader
             processAssignmentData();
             postProcessTasks();
             processDataLinks();
-            
+
             if (reader.getReadPresentationData())
             {
                processViewPropertyData();
@@ -145,7 +145,7 @@ final class MPP14Reader implements MPPVariantReader
       // 0x02 = write reservation password has been supplied
       // 0x03 = both passwords have been supplied
       //
-      if ((props14.getByte(Props.PASSWORD_FLAG) & 0x01) != 0)
+      if (! reader.getIgnorePassword() && (props14.getByte(Props.PASSWORD_FLAG) & 0x01) != 0)
       {
          // Couldn't figure out how to get the password for MPP14 files so for now we just need to block the reading
          throw new MPXJException(MPXJException.PASSWORD_PROTECTED);
@@ -978,7 +978,7 @@ final class MPP14Reader implements MPPVariantReader
          Props14 props = new Props14(m_inputStreamFactory.getInstance(taskDir, "Props"));
          new CustomFieldAliasReader(m_file.getCustomFields(), props.getByteArray(TASK_FIELD_NAME_ALIASES)).process();
       }
-      
+
       TreeMap<Integer, Integer> taskMap = createTaskMap(fieldMap, taskFixedMeta, taskFixedData, taskVarData);
       // The var data may not contain all the tasks as tasks with no var data assigned will
       // not be saved in there. Most notably these are tasks with no name. So use the task map
@@ -1605,7 +1605,7 @@ final class MPP14Reader implements MPPVariantReader
          Props14 props = new Props14(m_inputStreamFactory.getInstance(rscDir, "Props"));
          new CustomFieldAliasReader(m_file.getCustomFields(), props.getByteArray(RESOURCE_FIELD_NAME_ALIASES)).process();
       }
-      
+
       TreeMap<Integer, Integer> resourceMap = createResourceMap(fieldMap, rscFixedMeta, rscFixedData);
       Integer[] uniqueid = rscVarMeta.getUniqueIdentifierArray();
       Integer id;
@@ -1952,7 +1952,7 @@ final class MPP14Reader implements MPPVariantReader
       DataLinkFactory factory = new DataLinkFactory(m_file, fixedData, varData);
       factory.process();
    }
-   
+
    /**
     * Retrieve custom field value.
     *

--- a/src/main/java/net/sf/mpxj/mpp/MPP14Reader.java
+++ b/src/main/java/net/sf/mpxj/mpp/MPP14Reader.java
@@ -144,8 +144,10 @@ final class MPP14Reader implements MPPVariantReader
       // 0x01 = protection password has been supplied
       // 0x02 = write reservation password has been supplied
       // 0x03 = both passwords have been supplied
-      //
-      if (! reader.getIgnorePassword() && (props14.getByte(Props.PASSWORD_FLAG) & 0x01) != 0)
+      byte encryption = props14.getByte(Props.PASSWORD_FLAG);
+      boolean readEncrypted = (encryption & 0x1) != 0;
+      boolean writeEncrypted = (encryption & 0x2) != 0;
+      if (! reader.getIgnorePassword() && readEncrypted)
       {
          // Couldn't figure out how to get the password for MPP14 files so for now we just need to block the reading
          throw new MPXJException(MPXJException.PASSWORD_PROTECTED);
@@ -174,6 +176,8 @@ final class MPP14Reader implements MPPVariantReader
 
       m_file.getProjectProperties().setMppFileType(Integer.valueOf(14));
       m_file.getProjectProperties().setAutoFilter(props14.getBoolean(Props.AUTO_FILTER));
+      m_file.getProjectProperties().setReadEncrypted(readEncrypted);
+      m_file.getProjectProperties().setWriteEncrypted(writeEncrypted);
    }
 
    /**

--- a/src/main/java/net/sf/mpxj/mpp/MPP9Reader.java
+++ b/src/main/java/net/sf/mpxj/mpp/MPP9Reader.java
@@ -96,7 +96,7 @@ final class MPP9Reader implements MPPVariantReader
             processAssignmentData();
             postProcessTasks();
             processDataLinks();
-            
+
             if (reader.getReadPresentationData())
             {
                processViewPropertyData();
@@ -146,7 +146,7 @@ final class MPP9Reader implements MPPVariantReader
       // 0x02 = write reservation password has been supplied
       // 0x03 = both passwords have been supplied
       //
-      if ((props9.getByte(Props.PASSWORD_FLAG) & 0x01) != 0)
+      if (! reader.getIgnorePassword() && (props9.getByte(Props.PASSWORD_FLAG) & 0x01) != 0)
       {
          // File is password protected for reading, let's read the password
          // and see if the correct read password was given to us.

--- a/src/main/java/net/sf/mpxj/mpp/MPP9Reader.java
+++ b/src/main/java/net/sf/mpxj/mpp/MPP9Reader.java
@@ -145,8 +145,10 @@ final class MPP9Reader implements MPPVariantReader
       // 0x01 = protection password has been supplied
       // 0x02 = write reservation password has been supplied
       // 0x03 = both passwords have been supplied
-      //
-      if (! reader.getIgnorePassword() && (props9.getByte(Props.PASSWORD_FLAG) & 0x01) != 0)
+      byte encryption = props9.getByte(Props.PASSWORD_FLAG);
+      boolean readEncrypted = (encryption & 0x1) != 0;
+      boolean writeEncrypted = (encryption & 0x2) != 0;
+      if (! reader.getIgnorePassword() && readEncrypted)
       {
          // File is password protected for reading, let's read the password
          // and see if the correct read password was given to us.
@@ -180,6 +182,8 @@ final class MPP9Reader implements MPPVariantReader
 
       m_file.getProjectProperties().setMppFileType(Integer.valueOf(9));
       m_file.getProjectProperties().setAutoFilter(props9.getBoolean(Props.AUTO_FILTER));
+      m_file.getProjectProperties().setReadEncrypted(readEncrypted);
+      m_file.getProjectProperties().setWriteEncrypted(writeEncrypted);
    }
 
    /**

--- a/src/main/java/net/sf/mpxj/mpp/MPPReader.java
+++ b/src/main/java/net/sf/mpxj/mpp/MPPReader.java
@@ -368,6 +368,20 @@ public final class MPPReader extends AbstractProjectReader
    }
 
    /**
+    * Set whether this reader should ignore passwords on load.
+    * @param ignore
+    */
+   public void setIgnorePassword(boolean ignore)
+   {
+       m_ignorePassword = ignore;
+   }
+
+   boolean getIgnorePassword()
+   {
+       return m_ignorePassword;
+   }
+
+   /**
     * Flag used to indicate whether RTF formatting in notes should
     * be preserved. The default value for this flag is false.
     */
@@ -384,6 +398,8 @@ public final class MPPReader extends AbstractProjectReader
     */
    private boolean m_readPresentationData = true;
    private boolean m_readPropertiesOnly;
+
+   private boolean m_ignorePassword = false;
 
    private String m_readPassword;
    private List<ProjectListener> m_projectListeners;

--- a/src/main/java/net/sf/mpxj/reader/UniversalProjectReader.java
+++ b/src/main/java/net/sf/mpxj/reader/UniversalProjectReader.java
@@ -388,6 +388,7 @@ public final class UniversalProjectReader implements ProjectReader
       if (fileFormat != null && fileFormat.startsWith("MSProject"))
       {
          MPPReader reader = new MPPReader();
+         reader.setIgnorePassword(m_ignorePasswords);
          addListeners(reader);
          return reader.read(fs);
       }
@@ -834,9 +835,15 @@ public final class UniversalProjectReader implements ProjectReader
       }
    }
 
+   public void setIgnorePasswords(boolean ignore)
+   {
+       m_ignorePasswords = ignore;
+   }
+
    private int m_skipBytes;
    private Charset m_charset;
    private List<ProjectListener> m_projectListeners;
+   private boolean m_ignorePasswords;
 
    private static final int BUFFER_SIZE = 512;
 
@@ -1041,7 +1048,7 @@ public final class UniversalProjectReader implements ProjectReader
    private static final Pattern MSPDI_FINGERPRINT_1 = Pattern.compile(".*xmlns=\"http://schemas\\.microsoft\\.com/project.*", Pattern.DOTALL);
 
    private static final Pattern MSPDI_FINGERPRINT_2 = Pattern.compile(".*<Project.*<SaveVersion>.*", Pattern.DOTALL);
-   
+
    private static final Pattern PHOENIX_XML_FINGERPRINT = Pattern.compile(".*<project.*version=\"(\\d+|\\d+\\.\\d+)\".*update_mode=\"(true|false)\".*>.*", Pattern.DOTALL);
 
    private static final Pattern GANTTPROJECT_FINGERPRINT = Pattern.compile(".*<project.*webLink.*", Pattern.DOTALL);

--- a/src/test/java/net/sf/mpxj/junit/legacy/BasicTest.java
+++ b/src/test/java/net/sf/mpxj/junit/legacy/BasicTest.java
@@ -1313,6 +1313,7 @@ public class BasicTest
    {
       File in;
       MPPReader reader;
+      ProjectFile projectFile;
 
       //
       // Read password (password1)
@@ -1333,12 +1334,16 @@ public class BasicTest
       in = new File(MpxjTestData.filePath("legacy/readpassword9.mpp"));
       reader = new MPPReader();
       reader.setIgnorePassword(true);
-      reader.read(in);
+      projectFile = reader.read(in);
+      assertTrue(projectFile.getProjectProperties().getReadEncrypted());
+      assertFalse(projectFile.getProjectProperties().getWriteEncrypted());
       //
       // Write password (password2)
       //
       in = new File(MpxjTestData.filePath("legacy/writepassword9.mpp"));
-      new MPPReader().read(in);
+      projectFile = new MPPReader().read(in);
+      assertFalse(projectFile.getProjectProperties().getReadEncrypted());
+      assertTrue(projectFile.getProjectProperties().getWriteEncrypted());
 
       //
       // Read password
@@ -1357,7 +1362,9 @@ public class BasicTest
       in = new File(MpxjTestData.filePath("legacy/bothpassword9.mpp"));
       reader = new MPPReader();
       reader.setIgnorePassword(true);
-      reader.read(in);
+      projectFile = reader.read(in);
+      assertTrue(projectFile.getProjectProperties().getReadEncrypted());
+      assertTrue(projectFile.getProjectProperties().getWriteEncrypted());
    }
 
    /**
@@ -1496,6 +1503,8 @@ public class BasicTest
       assertEquals("Keywords Text", properties.getKeywords());
       assertEquals("Manager Text", properties.getManager());
       assertEquals("Subject Text", properties.getSubject());
+      assertFalse(properties.getReadEncrypted());
+      assertFalse(properties.getWriteEncrypted());
    }
 
    /**

--- a/src/test/java/net/sf/mpxj/junit/legacy/BasicTest.java
+++ b/src/test/java/net/sf/mpxj/junit/legacy/BasicTest.java
@@ -1312,6 +1312,7 @@ public class BasicTest
    @Test public void testPasswordProtection() throws Exception
    {
       File in;
+      MPPReader reader;
 
       //
       // Read password (password1)
@@ -1328,6 +1329,11 @@ public class BasicTest
          assertEquals(MPXJException.PASSWORD_PROTECTED_ENTER_PASSWORD, ex.getMessage());
       }
 
+      // Ignore password mode.
+      in = new File(MpxjTestData.filePath("legacy/readpassword9.mpp"));
+      reader = new MPPReader();
+      reader.setIgnorePassword(true);
+      reader.read(in);
       //
       // Write password (password2)
       //
@@ -1348,6 +1354,10 @@ public class BasicTest
       {
          assertEquals(MPXJException.PASSWORD_PROTECTED_ENTER_PASSWORD, ex.getMessage());
       }
+      in = new File(MpxjTestData.filePath("legacy/bothpassword9.mpp"));
+      reader = new MPPReader();
+      reader.setIgnorePassword(true);
+      reader.read(in);
    }
 
    /**


### PR DESCRIPTION
From my reading of the MPP parsing code and testing with sample files, the password-protection offered is entirely application-enforced - decryption is possible (using the `Props.ENCRYPTION_CODE` mask) even without the password. While doing so might seem unsavory, for some applications (e.g. data recovery, forensics) it might make sense. Please let me know if this isn't actually the case - I'm sure you have much more knowledge of the file format than I do! At the very least I am able to extract task information from some private "encrypted" files as well as the sample "bothpassword9.mpp" and "readpassword9.mpp" files in the repo.

This PR simply adds a flag to `MPPReader` (also exposed through `UniversalProjectReader`, although if you feel it isn't sufficiently universal, I'm happy to remove it there) to ignore password checks on load. 