### PR TITLE
DataTypeConverter.printUUID() to return upper case

### DIFF
--- a/src/main/java/net/sf/mpxj/mspdi/DatatypeConverter.java
+++ b/src/main/java/net/sf/mpxj/mspdi/DatatypeConverter.java
@@ -1393,7 +1393,7 @@ public final class DatatypeConverter
     */
    public static String printUUID(UUID guid)
    {
-      return guid == null ? null : guid.toString();
+      return guid == null ? null : guid.toString().toUpperCase();
    }
 
    /**


### PR DESCRIPTION
MSPDI writer normally emits XML like the following when the GUID is set:

```xml
...
    <Task>
      <UID>1</UID>
      <GUID>11ac0344-fb07-400f-a515-9f622ee3cfd5</GUID>
      <ID>1</ID>
      <Name>T1</Name>
      <Type>0</Type>
…
```

If you import this XML into Microsoft Project and check the GUID column of tasks, you will see that another GUID has been assigned instead.

Returning to the XML file and making the GUID upper case and repeating the same activity, results in MSP accepting the GUID value so that you can exert more control over the task identification for syncing with external systems.