### PR TITLE
Ruby - add possibility of loading JAXB in class path.

### DIFF
--- a/src.ruby/mpxj/README.md
+++ b/src.ruby/mpxj/README.md
@@ -25,6 +25,13 @@ Or install it yourself as:
 ## Changelog
 You'll find details of what has changed in this version [here](http://mpxj.sourceforge.net/changes-report.html).
 
+## Java 11 or newer
+
+Newer version of java doesn't have JAXB library build-in. 
+You need to install it manually [more info here](https://javaee.github.io/jaxb-v2/)
+After installing you need to specify path from where it will be loaded.
+You can do that by setting environment variable `JAXB_LIB_PATH` pointing to directory with `.jar` files. 
+
 ## Supported File Types
 
 This gem uses the file name extension to determine what kind of project data it is reading. The list below shows the supported file extensions:

--- a/src.ruby/mpxj/lib/mpxj/reader.rb
+++ b/src.ruby/mpxj/lib/mpxj/reader.rb
@@ -21,7 +21,7 @@ module MPXJ
 
       begin
         classpath = Dir["#{File.dirname(__FILE__)}/*.jar"]
-        classpath += Dir["#{File.dirname(ENV['JAXB_LIB_PATH'])}/*.jar"] if ENV['JAXB_LIB_PATH'] && ENV['JAXB_LIB_PATH'] != ''
+        classpath += Dir["#{File.expand_path(ENV['JAXB_LIB_PATH'])}/*.jar"] if ENV['JAXB_LIB_PATH'] && ENV['JAXB_LIB_PATH'] != ''
         java_output = `java -cp \"#{classpath.join(path_separator)}\" #{jvm_args} net.sf.mpxj.sample.MpxjConvert \"#{file_name}\" \"#{json_file.path}\"`
         if $?.exitstatus != 0
           report_error(java_output)

--- a/src.ruby/mpxj/lib/mpxj/reader.rb
+++ b/src.ruby/mpxj/lib/mpxj/reader.rb
@@ -20,8 +20,9 @@ module MPXJ
       tz = zone || Time.zone || ActiveSupport::TimeZone["UTC"]
 
       begin
-        classpath = Dir["#{File.dirname(__FILE__)}/*.jar"].join(path_separator)
-        java_output = `java -cp \"#{classpath}\" #{jvm_args} net.sf.mpxj.sample.MpxjConvert \"#{file_name}\" \"#{json_file.path}\"`
+        classpath = Dir["#{File.dirname(__FILE__)}/*.jar"]
+        classpath += Dir["#{File.dirname(Env['JAXB_LIB_PATH'])}/*.jar"] if Env['JAXB_LIB_PATH'] && Env['JAXB_LIB_PATH'] != ''
+        java_output = `java -cp \"#{classpath.join(path_separator)}\" #{jvm_args} net.sf.mpxj.sample.MpxjConvert \"#{file_name}\" \"#{json_file.path}\"`
         if $?.exitstatus != 0
           report_error(java_output)
         end

--- a/src.ruby/mpxj/lib/mpxj/reader.rb
+++ b/src.ruby/mpxj/lib/mpxj/reader.rb
@@ -21,7 +21,7 @@ module MPXJ
 
       begin
         classpath = Dir["#{File.dirname(__FILE__)}/*.jar"]
-        classpath += Dir["#{File.dirname(Env['JAXB_LIB_PATH'])}/*.jar"] if Env['JAXB_LIB_PATH'] && Env['JAXB_LIB_PATH'] != ''
+        classpath += Dir["#{File.dirname(ENV['JAXB_LIB_PATH'])}/*.jar"] if ENV['JAXB_LIB_PATH'] && ENV['JAXB_LIB_PATH'] != ''
         java_output = `java -cp \"#{classpath.join(path_separator)}\" #{jvm_args} net.sf.mpxj.sample.MpxjConvert \"#{file_name}\" \"#{json_file.path}\"`
         if $?.exitstatus != 0
           report_error(java_output)


### PR DESCRIPTION
Problem
In Java 11 `--add-modules java.xml.bind` doesn't work, so JAXB `.jar` files need to be specified in the classpath. 

Solution
Make it possible to load JAXB jar files by setting `JAXB_LIB_PATH` env variable.