### PR TITLE
Updated version of sqlite-jdbc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -34,7 +34,7 @@
 		<property name="commons-collections.jar" value="commons-collections4-4.4" />
 		<property name="commons-math.jar" value="commons-math3-3.6.1" />
 		<property name="rtfparserkit.jar" value="rtfparserkit-1.16.0" />
-		<property name="sqlite-jdbc.jar" value="sqlite-jdbc-3.30.1" />
+		<property name="sqlite-jdbc.jar" value="sqlite-jdbc-3.36.0.3" />
 		<property name="jsoup.jar" value="jsoup-1.14.2" />
 		<property name="junit.jar" value="junit-4.13.1"/>
 		<property name="hamcrest.jar" value="hamcrest-core-1.3"/>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<artifactId>mpxj</artifactId>
 
 	<!-- Note - this is automatically updated by the ant build ... don't remove the MPXJ comment! -->
-	<!-- MPXJ --><version>10.6.0</version>
+	<!-- MPXJ --><version>10.6.1</version>
 
 	<name>MPXJ</name>
 	<url>http://mpxj.org</url>
@@ -33,7 +33,7 @@
 		<dependency>
 			<groupId>org.xerial</groupId>
 			<artifactId>sqlite-jdbc</artifactId>
-			<version>3.30.1</version>
+			<version>3.36.0.3</version>
 		</dependency>
 
 		<dependency>

--- a/src.ruby/mpxj/lib/mpxj/version.rb
+++ b/src.ruby/mpxj/lib/mpxj/version.rb
@@ -1,5 +1,5 @@
 # MPXJ gem module
 module MPXJ
   # MPXJ gem version number
-  VERSION = "10.6.0"
+  VERSION = "10.6.1"
 end


### PR DESCRIPTION
__Tech__
- Updated version of sqlite-jdbc to fix Arm64 architecture and M1 mac issue.

Note: This mpxj plugin was giving error on M1 arch64 due to Java sqlite-jdbc implementation which is fixed on sqlite but our plugin is still using outdated version.