### PR TITLE
[SECURITY] Fix Temporary File Information Disclosure Vulnerability


### DIFF
--- a/src/main/java/net/sf/mpxj/common/FileHelper.java
+++ b/src/main/java/net/sf/mpxj/common/FileHelper.java
@@ -25,6 +25,7 @@ package net.sf.mpxj.common;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 /**
  * Common helper methods for working with files.
@@ -110,7 +111,7 @@ public final class FileHelper
     */
    public static final File createTempDir() throws IOException
    {
-      File dir = File.createTempFile("mpxj", "tmp");
+      File dir = Files.createTempFile("mpxj", "tmp").toFile();
       delete(dir);
       mkdirs(dir);
       return dir;

--- a/src/main/java/net/sf/mpxj/common/InputStreamHelper.java
+++ b/src/main/java/net/sf/mpxj/common/InputStreamHelper.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
@@ -49,7 +50,7 @@ public class InputStreamHelper
 
       try
       {
-         File file = File.createTempFile("mpxj", tempFileSuffix);
+         File file = Files.createTempFile("mpxj", tempFileSuffix).toFile();
          outputStream = new FileOutputStream(file);
          byte[] buffer = new byte[1024];
          while (true)

--- a/src/test/java/net/sf/mpxj/junit/CustomerDataTest.java
+++ b/src/test/java/net/sf/mpxj/junit/CustomerDataTest.java
@@ -174,7 +174,7 @@ public class CustomerDataTest
 
       // Accessing the database directly from (new) Google Drive is too slow.
       // Make a temporary local copy instead.
-      File file = File.createTempFile("primavera", "db");
+      File file = Files.createTempFile("primavera", "db").toFile();
       file.deleteOnExit();
       Files.copy(new File(m_primaveraFile).toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
@@ -616,7 +616,7 @@ public class CustomerDataTest
 
       if (baselineFile.exists())
       {
-         File out = File.createTempFile("junit", suffix);
+         File out = Files.createTempFile("junit", suffix).toFile();
          writer.write(project, out);
          success = FileUtility.equals(baselineFile, out);
 

--- a/src/test/java/net/sf/mpxj/junit/LocaleTest.java
+++ b/src/test/java/net/sf/mpxj/junit/LocaleTest.java
@@ -26,6 +26,7 @@ package net.sf.mpxj.junit;
 import static net.sf.mpxj.junit.MpxjAssert.*;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.Locale;
 
 import org.junit.Test;
@@ -64,7 +65,7 @@ public class LocaleTest
 
       File in = new File(MpxjTestData.filePath("legacy/sample.mpx"));
       ProjectFile mpx = reader.read(in);
-      File out = File.createTempFile("junit-" + locale.getLanguage(), ".mpx");
+      File out = Files.createTempFile("junit-" + locale.getLanguage(), ".mpx").toFile();
       writer.setLocale(locale);
       writer.write(mpx, out);
 

--- a/src/test/java/net/sf/mpxj/junit/legacy/BasicTest.java
+++ b/src/test/java/net/sf/mpxj/junit/legacy/BasicTest.java
@@ -26,6 +26,7 @@ package net.sf.mpxj.junit.legacy;
 import static org.junit.Assert.*;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
@@ -74,7 +75,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/sample.mpx"));
       ProjectFile mpx = new MPXReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       MPXWriter writer = new MPXWriter();
       writer.setUseLocaleDefaults(false);
       writer.write(mpx, out);
@@ -93,7 +94,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/sample1.xml"));
       ProjectFile xml = new MSPDIReader().read(in);
-      File out = File.createTempFile("junit", ".xml");
+      File out = Files.createTempFile("junit", ".xml").toFile();
       new MSPDIWriter().write(xml, out);
       boolean success = FileUtility.equals(in, out);
       assertTrue("Files are not identical", success);
@@ -110,7 +111,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/sample1.mpx"));
       ProjectFile mpx = new MPXReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       MPXWriter writer = new MPXWriter();
       writer.setUseLocaleDefaults(false);
       writer.write(mpx, out);
@@ -128,7 +129,7 @@ public class BasicTest
       File in = new File(MpxjTestData.filePath("legacy/empty.mpp"));
       ProjectFile mpx = new MPPReader().read(in);
       mpx.getProjectProperties().setCurrentDate(new SimpleDateFormat("dd/MM/yyyy").parse("01/03/2006"));
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       MPXWriter writer = new MPXWriter();
       writer.setUseLocaleDefaults(false);
       writer.write(mpx, out);
@@ -144,7 +145,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/sample.mpx"));
       ProjectFile mpx = new MPXReader().read(in);
-      File out = File.createTempFile("junit", ".planner");
+      File out = Files.createTempFile("junit", ".planner").toFile();
       new PlannerWriter().write(mpx, out);
       //success = FileUtility.equals (in, out);
       //assertTrue ("Files are not identical", success);
@@ -267,7 +268,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/sample98.mpp"));
       ProjectFile mpp = new MPPReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(mpp, out);
       commonTests(mpp);
       out.deleteOnExit();
@@ -280,7 +281,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/sample.mpp"));
       ProjectFile mpp = new MPPReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(mpp, out);
       commonTests(mpp);
       out.deleteOnExit();
@@ -293,7 +294,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/sample.xml"));
       ProjectFile xml = new MSPDIReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(xml, out);
       commonTests(xml);
       out.deleteOnExit();
@@ -353,12 +354,12 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/sample.mpp"));
       ProjectFile mpp = new MPPReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(mpp, out);
 
       ProjectFile mpx = new MPXReader().read(out);
       out.deleteOnExit();
-      out = File.createTempFile("junit", ".xml");
+      out = Files.createTempFile("junit", ".xml").toFile();
       new MSPDIWriter().write(mpx, out);
       out.deleteOnExit();
    }
@@ -428,7 +429,7 @@ public class BasicTest
       task5.setStart(new Date());
       task5.setNotes(notes5);
 
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(file1, out);
 
       ProjectFile file2 = new MPXReader().read(out);
@@ -490,7 +491,7 @@ public class BasicTest
       resource5.setName("Test Resource 5");
       resource5.setNotes(notes5);
 
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(file1, out);
 
       ProjectFile file2 = new MPXReader().read(out);
@@ -524,7 +525,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/bug1.mpp"));
       ProjectFile mpp = new MPPReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(mpp, out);
       out.deleteOnExit();
    }
@@ -536,7 +537,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/bug2.mpp"));
       ProjectFile mpp = new MPPReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(mpp, out);
       out.deleteOnExit();
    }
@@ -563,7 +564,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/bug4.mpp"));
       ProjectFile mpp = new MPPReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(mpp, out.getAbsolutePath());
       out.deleteOnExit();
    }
@@ -896,7 +897,7 @@ public class BasicTest
       //
       // Write this out as an MSPDI file
       //
-      File out = File.createTempFile("junit", ".xml");
+      File out = Files.createTempFile("junit", ".xml").toFile();
       new MSPDIWriter().write(mpp, out);
 
       //
@@ -927,7 +928,7 @@ public class BasicTest
       ProjectFile xml = reader.read(in);
       validateAliases(xml);
 
-      File out = File.createTempFile("junit", ".xml");
+      File out = Files.createTempFile("junit", ".xml").toFile();
       writer.write(xml, out);
 
       xml = reader.read(out);
@@ -1247,7 +1248,7 @@ public class BasicTest
       //
       // Write the file
       //
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(file, out);
 
       //
@@ -1338,7 +1339,7 @@ public class BasicTest
       ProjectFile xml = reader.read(MpxjTestData.filePath("legacy/mspextattr.xml"));
       commonMspdiExtendedAttributeTests(xml);
 
-      File out = File.createTempFile("junit", ".xml");
+      File out = Files.createTempFile("junit", ".xml").toFile();
       writer.write(xml, out);
 
       xml = reader.read(out);
@@ -1404,7 +1405,7 @@ public class BasicTest
       // Write the file, re-read it and test to ensure that
       // the project properties have the expected values
       //
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       writer.write(mpx, out);
       mpx = reader.read(out);
       testProperties(mpx);
@@ -1435,7 +1436,7 @@ public class BasicTest
       // Write the file, re-read it and test to ensure that
       // the project properties have the expected values
       //
-      out = File.createTempFile("junit", ".xml");
+      out = Files.createTempFile("junit", ".xml").toFile();
       new MSPDIWriter().write(mpx, out);
 
       mpx = new MSPDIReader().read(out);
@@ -1512,13 +1513,13 @@ public class BasicTest
       ProjectFile xml = new MSPDIReader().read(MpxjTestData.filePath("legacy/mspdipriority.xml"));
       validatePriority(xml);
 
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(mpx, out);
       ProjectFile mpx2 = new MPXReader().read(out);
       validatePriority(mpx2);
       out.deleteOnExit();
 
-      out = File.createTempFile("junit", ".xml");
+      out = Files.createTempFile("junit", ".xml").toFile();
       new MSPDIWriter().write(mpx, out);
       ProjectFile xml3 = new MSPDIReader().read(out);
       validatePriority(xml3);
@@ -1720,7 +1721,7 @@ public class BasicTest
       //
       // Write the file and re-read it to ensure we get consistent results.
       //
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       new MPXWriter().write(mpp, out);
 
       ProjectFile mpx = new MPXReader().read(out);
@@ -1737,7 +1738,7 @@ public class BasicTest
    {
       File in = new File(MpxjTestData.filePath("legacy/calendarExceptions.mpx"));
       ProjectFile mpx = new MPXReader().read(in);
-      File out = File.createTempFile("junit", ".mpx");
+      File out = Files.createTempFile("junit", ".mpx").toFile();
       MPXWriter writer = new MPXWriter();
       writer.setUseLocaleDefaults(false);
       writer.write(mpx, out);


### PR DESCRIPTION

# Security Vulnerability Fix

This pull request fixes a Temporary File Information Disclosure Vulnerability, which existed in this project.

## Preamble

The system temporary directory is shared between all users on most unix-like systems (not MacOS, or Windows). Thus, code interacting with the system temporary directory must be careful about file interactions in this directory, and must ensure that the correct file posix permissions are set.

This PR was generated because a call to `File.createTempFile(..)` was detected in this repository in a way that makes this project vulnerable to local information disclosure.
With the default uname configuration, `File.createTempFile(..)` creates a file with the permissions `-rw-r--r--`. This means that any other user on the system can read the contents of this file.

### Impact

Information in this file is visible to other local users, allowing a malicious actor co-resident on the same machine to view potentially sensitive files.

#### Other Examples

 - [CVE-2020-15250](https://github.com/advisories/GHSA-269g-pwp5-87pp) - junit-team/junit
 - [CVE-2021-21364](https://github.com/advisories/GHSA-hpv8-9rq5-hq7w) - swagger-api/swagger-codegen
 - [CVE-2022-24823](https://github.com/advisories/GHSA-5mcr-gq6c-3hq2) - netty/netty
 - [CVE-2022-24823](https://github.com/advisories/GHSA-269q-hmxg-m83q) - netty/netty

# The Fix

The fix has been to convert the logic above to use the following API that was introduced in Java 1.7.

```java
File tmpDir = Files.createTempFile("temp dir").toFile();
```

The API both creates the file securely, ie. with a random, non-conflicting name, with file permissions that only allow the currently executing user to read or write the contents of this file.
By default, `Files.createTempFile("temp dir")` will create a file with the permissions `-rw-------`, which only allows the user that created the file to view/write the file contents.

# :arrow_right: Vulnerability Disclosure :arrow_left:

:wave: Vulnerability disclosure is a super important part of the vulnerability handling process and should not be skipped! This may be completely new to you, and that's okay, I'm here to assist!

First question, do we need to perform vulnerability disclosure? It depends!

 1. Is the vulnerable code only in tests or example code? No disclosure required!
 2. Is the vulnerable code in code shipped to your end users? Vulnerability disclosure is probably required!

## Vulnerability Disclosure How-To

You have a few options options to perform vulnerability disclosure. However, I'd like to suggest the following 2 options:

 1. Request a CVE number from GitHub by creating a repository-level [GitHub Security Advisory](https://docs.github.com/en/code-security/repository-security-advisories/creating-a-repository-security-advisory). This has the advantage that, if you provide sufficient information, GitHub will automatically generate Dependabot alerts for your downstream consumers, resolving this vulnerability more quickly.
 2. Reach out to the team at Snyk to assist with CVE issuance. They can be reached at the [Snyk's Disclosure Email](mailto:report@snyk.io).

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by GitHub's CodeQL using this [CodeQL Query](https://codeql.github.com/codeql-query-help/java/java-local-temp-file-or-directory-information-disclosure/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [GitHub Action](https://github.com/github/codeql-action).

I'm not an employee of GitHub, I'm simply an open-source security researcher.

## Source

This contribution was automatically generated with an [OpenRewrite](https://github.com/openrewrite/rewrite) [refactoring recipe](https://docs.openrewrite.org/), which was lovingly hand crafted to bring this security fix to your repository.

The source code that generated this PR can be found here:
[SecureTempFileCreation](https://github.com/openrewrite/rewrite-java-security/blob/main/src/main/java/org/openrewrite/java/security/SecureTempFileCreation.java)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/security-research
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Sponsorship & Support

This contribution is sponsored by HUMAN Security Inc. and the new Dan Kaminsky Fellowship, a fellowship created to celebrate Dan's memory and legacy by funding open-source work that makes the world a better (and more secure) place.

This PR was generated by [Moderne](https://www.moderne.io/), a free-for-open source SaaS offering that uses format-preserving AST transformations to fix bugs, standardize code style, apply best practices, migrate library versions, and fix common security vulnerabilities at scale.

## Tracking

All PR's generated as part of this fix are tracked here: https://github.com/JLLeitschuh/security-research/issues/18
