### PR TITLE
Speed up the XER parse

### DIFF
--- a/src/main/java/org/mpxj/ActivityCode.java
+++ b/src/main/java/org/mpxj/ActivityCode.java
@@ -177,7 +177,15 @@ public final class ActivityCode implements Code
       }
 
       // I'd prefer a map-based lookup, but this will do for now and the list of values will typically be fairly short
-      return m_values.stream().filter(v -> v.getUniqueID().intValue() == id.intValue()).findFirst().orElse(null);
+      for (ActivityCodeValue value : m_values)
+      {
+         if (value.getUniqueID().intValue() == id.intValue())
+         {
+            return value;
+         }
+      }
+
+      return null;
    }
 
    private final Integer m_uniqueID;

--- a/src/main/java/org/mpxj/ProjectCalendar.java
+++ b/src/main/java/org/mpxj/ProjectCalendar.java
@@ -1440,7 +1440,6 @@ public class ProjectCalendar extends ProjectCalendarDays implements ProjectEntit
          return elapsedMinutes.convertUnits(format, this);
       }
 
-      LocalDateTimeRange range = new LocalDateTimeRange(startDate, endDate);
       long totalTime = 0;
 
       //
@@ -1457,9 +1456,14 @@ public class ProjectCalendar extends ProjectCalendarDays implements ProjectEntit
          endDate = temp;
       }
 
-      if (isSameDay(startDate, endDate))
+      // Only the day advances from here, so step a LocalDate rather than a LocalDateTime:
+      // plusDays on the latter builds a LocalDate and then wraps it, for every day of the range.
+      LocalDate startDay = startDate.toLocalDate();
+      LocalDate endDay = endDate.toLocalDate();
+
+      if (startDay.equals(endDay))
       {
-         ProjectCalendarHours ranges = getRanges(LocalDateHelper.getLocalDate(startDate));
+         ProjectCalendarHours ranges = getRanges(startDay);
          if (!ranges.isEmpty())
          {
             totalTime = getTotalTime(ranges, LocalTimeHelper.getLocalTime(startDate), LocalTimeHelper.getLocalTime(endDate));
@@ -1467,44 +1471,39 @@ public class ProjectCalendar extends ProjectCalendarDays implements ProjectEntit
       }
       else
       {
-         LocalDateTime canonicalEndDate = LocalDateTimeHelper.getDayStartDate(endDate);
-
          //
          // Find the first working day in the range
          //
-         LocalDateTime currentDate = startDate;
-         LocalDateTime cal = startDate;
-         while (!isWorkingDate(LocalDateHelper.getLocalDate(currentDate)) && currentDate.isBefore(canonicalEndDate))
+         LocalDate currentDay = startDay;
+         while (!isWorkingDate(currentDay) && currentDay.isBefore(endDay))
          {
-            cal = cal.plusDays(1);
-            currentDate = cal;
+            currentDay = currentDay.plusDays(1);
          }
 
-         if (currentDate.isBefore(canonicalEndDate))
+         if (currentDay.isBefore(endDay))
          {
             // If the first working day is the same as the start date, we leave
             // the date alone to preserve the start time. If we have moved past
             // the start date to find the first working day, reset the time
             // of day to ensure that we use all working hours on this day.
-            LocalTime targetTime = currentDate.equals(startDate) ? LocalTimeHelper.getLocalTime(currentDate) : LocalTime.of(0, 0);
+            LocalTime targetTime = currentDay.equals(startDay) ? LocalTimeHelper.getLocalTime(startDate) : LocalTime.of(0, 0);
 
             //
             // Calculate the amount of working time for this day
             //
-            totalTime += getTotalTime(getRanges(LocalDateHelper.getLocalDate(currentDate)), targetTime);
+            totalTime += getTotalTime(getRanges(currentDay), targetTime);
 
             //
             // Process each working day until we reach the last day
             //
             while (true)
             {
-               cal = cal.plusDays(1);
-               currentDate = cal;
+               currentDay = currentDay.plusDays(1);
 
                //
                // We have reached the last day
                //
-               if (!currentDate.isBefore(canonicalEndDate))
+               if (!currentDay.isBefore(endDay))
                {
                   break;
                }
@@ -1512,7 +1511,7 @@ public class ProjectCalendar extends ProjectCalendarDays implements ProjectEntit
                //
                // Skip this day if it has no working time
                //
-               ProjectCalendarHours ranges = getRanges(LocalDateHelper.getLocalDate(currentDate));
+               ProjectCalendarHours ranges = getRanges(currentDay);
                if (ranges.isEmpty())
                {
                   continue;
@@ -1528,7 +1527,7 @@ public class ProjectCalendar extends ProjectCalendarDays implements ProjectEntit
          //
          // We are now at the last day
          //
-         ProjectCalendarHours ranges = getRanges(LocalDateHelper.getLocalDate(endDate));
+         ProjectCalendarHours ranges = getRanges(endDay);
          if (!ranges.isEmpty())
          {
             totalTime += getTotalTime(ranges, LocalTime.of(0, 0), LocalTimeHelper.getLocalTime(endDate));
@@ -1541,16 +1540,6 @@ public class ProjectCalendar extends ProjectCalendarDays implements ProjectEntit
       }
 
       return convertFormat(totalTime, format);
-   }
-
-   private boolean isSameDay(LocalDateTime d1, LocalDateTime d2)
-   {
-      if (d1 == null || d2 == null)
-      {
-         return false;
-      }
-
-      return d1.getYear() == d2.getYear() && d1.getDayOfYear() == d2.getDayOfYear();
    }
 
    /**
@@ -1877,7 +1866,7 @@ public class ProjectCalendar extends ProjectCalendarDays implements ProjectEntit
 
       // Use the day type to retrieve the ranges
       DayOfWeek day = date.getDayOfWeek();
-      switch (week.getCalendarDayType(date.getDayOfWeek()))
+      switch (week.getCalendarDayType(day))
       {
          case NON_WORKING:
          {

--- a/src/main/java/org/mpxj/ProjectCalendar.java
+++ b/src/main/java/org/mpxj/ProjectCalendar.java
@@ -1681,7 +1681,13 @@ public class ProjectCalendar extends ProjectCalendarDays implements ProjectEntit
     */
    private long getTotalTime(ProjectCalendarHours hours)
    {
-      return hours.stream().mapToLong(LocalTimeRange::getDurationAsMilliseconds).sum();
+      // getWork calls this once per day across a date range, so keep it allocation-free.
+      long total = 0;
+      for (LocalTimeRange range : hours)
+      {
+         total += range.getDurationAsMilliseconds();
+      }
+      return total;
    }
 
    /**

--- a/src/main/java/org/mpxj/common/NumberHelper.java
+++ b/src/main/java/org/mpxj/common/NumberHelper.java
@@ -24,7 +24,7 @@
 package org.mpxj.common;
 
 import java.math.BigInteger;
-import java.util.Arrays;
+import java.util.DoubleSummaryStatistics;
 
 /**
  * This class contains utility methods for handling Number objects and
@@ -287,7 +287,16 @@ public final class NumberHelper
     */
    public static Double sumAsDouble(Number... values)
    {
-      return Double.valueOf(Arrays.stream(values).mapToDouble(NumberHelper::getDouble).sum());
+      // The same compensated summation DoubleStream.sum performs, without the pipeline it builds
+      // per call. Delegating rather than copying keeps the two in step: the convention they share
+      // changed after Java 8, where both add the compensation rather than subtracting it.
+      DoubleSummaryStatistics summary = new DoubleSummaryStatistics();
+      for (Number value : values)
+      {
+         summary.accept(getDouble(value));
+      }
+
+      return getDouble(summary.getSum());
    }
 
    public static final Double DOUBLE_ZERO = Double.valueOf(0);

--- a/src/main/java/org/mpxj/common/ReaderTokenizer.java
+++ b/src/main/java/org/mpxj/common/ReaderTokenizer.java
@@ -23,7 +23,6 @@
 
 package org.mpxj.common;
 
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 
@@ -31,7 +30,10 @@ import java.io.Reader;
  * This class implements a tokenizer as per the underlying Tokenizer class,
  * with characters being read from a Reader instance.
  *
- * The reader is buffered if it is not already.
+ * Characters are read in blocks: Reader.read() with no argument goes through
+ * StreamDecoder per call, taking a lock and allocating for each character.
+ * The Reader is therefore read ahead of the current token, so it must not be
+ * shared with anything which reads from it afterwards.
  */
 public class ReaderTokenizer extends Tokenizer
 {
@@ -42,13 +44,30 @@ public class ReaderTokenizer extends Tokenizer
     */
    public ReaderTokenizer(Reader r)
    {
-      m_reader = (r instanceof BufferedReader) ? r : new BufferedReader(r);
+      m_reader = r;
    }
 
    @Override protected int read() throws IOException
    {
-      return (m_reader.read());
+      if (m_index == m_length)
+      {
+         m_length = m_reader.read(m_readBuffer);
+         m_index = 0;
+
+         if (m_length < 1)
+         {
+            m_length = 0;
+            return TT_EOF;
+         }
+      }
+
+      return m_readBuffer[m_index++];
    }
 
    private final Reader m_reader;
+   private final char[] m_readBuffer = new char[BUFFER_SIZE];
+   private int m_index;
+   private int m_length;
+
+   private static final int BUFFER_SIZE = 8192;
 }

--- a/src/main/java/org/mpxj/common/ReaderTokenizer.java
+++ b/src/main/java/org/mpxj/common/ReaderTokenizer.java
@@ -23,12 +23,15 @@
 
 package org.mpxj.common;
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Reader;
 
 /**
  * This class implements a tokenizer as per the underlying Tokenizer class,
  * with characters being read from a Reader instance.
+ *
+ * The reader is buffered if it is not already.
  */
 public class ReaderTokenizer extends Tokenizer
 {
@@ -39,7 +42,7 @@ public class ReaderTokenizer extends Tokenizer
     */
    public ReaderTokenizer(Reader r)
    {
-      m_reader = r;
+      m_reader = (r instanceof BufferedReader) ? r : new BufferedReader(r);
    }
 
    @Override protected int read() throws IOException

--- a/src/main/java/org/mpxj/primavera/WorkHelper.java
+++ b/src/main/java/org/mpxj/primavera/WorkHelper.java
@@ -22,8 +22,7 @@
 
 package org.mpxj.primavera;
 
-import java.util.Arrays;
-import java.util.Objects;
+import java.util.DoubleSummaryStatistics;
 
 import org.mpxj.Duration;
 import org.mpxj.Task;
@@ -42,7 +41,17 @@ class WorkHelper
     */
    public static Duration addWork(Duration... values)
    {
-      return Duration.getInstance(Arrays.stream(values).filter(Objects::nonNull).mapToDouble(Duration::getDuration).sum(), TimeUnit.HOURS);
+      // As NumberHelper.sumAsDouble: the JDK's own compensated summation, without a stream pipeline.
+      DoubleSummaryStatistics summary = new DoubleSummaryStatistics();
+      for (Duration value : values)
+      {
+         if (value != null)
+         {
+            summary.accept(value.getDuration());
+         }
+      }
+
+      return Duration.getInstance(summary.getSum(), TimeUnit.HOURS);
    }
 
    /**

--- a/src/main/java/org/mpxj/primavera/XerFile.java
+++ b/src/main/java/org/mpxj/primavera/XerFile.java
@@ -29,6 +29,8 @@ import java.nio.charset.Charset;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
+import java.time.DateTimeException;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -340,16 +342,7 @@ class XerFile
             {
                case DATE:
                {
-                  try
-                  {
-                     objectValue = LocalDateTimeHelper.parseBest(m_df, fieldValue);
-                  }
-
-                  catch (DateTimeParseException ex)
-                  {
-                     objectValue = fieldValue;
-                  }
-
+                  objectValue = parseDate(fieldValue);
                   break;
                }
 
@@ -475,6 +468,96 @@ class XerFile
       }
 
       return value.replace("\"\"", "\"");
+   }
+
+   /**
+    * Reads a date field, taking a fast path for the shapes P6 writes. Anything else
+    * falls back to the formatter, so the formats accepted are unchanged.
+    *
+    * @param value string value
+    * @return LocalDateTime, or the original string where it cannot be read as a date
+    */
+   private Object parseDate(String value)
+   {
+      LocalDateTime fast = parseCanonicalDate(value);
+      if (fast != null)
+      {
+         return fast;
+      }
+
+      try
+      {
+         return LocalDateTimeHelper.parseBest(m_df, value);
+      }
+
+      catch (DateTimeParseException ex)
+      {
+         return value;
+      }
+   }
+
+   /**
+    * Reads "yyyy-MM-dd", "yyyy-MM-dd HH:mm" or "yyyy-MM-dd HH:mm:ss". Returns null for
+    * anything else, including out of range components and year zero, which the formatter
+    * rejects as it has no year zero in an era.
+    *
+    * @param value string value
+    * @return LocalDateTime, or null where the value is not one of those shapes
+    */
+   private static LocalDateTime parseCanonicalDate(String value)
+   {
+      int length = value.length();
+      if ((length != 10 && length != 16 && length != 19)
+         || (value.charAt(4) != '-')
+         || (value.charAt(7) != '-')
+         || (length > 10 && (value.charAt(10) != ' ' || value.charAt(13) != ':'))
+         || (length == 19 && value.charAt(16) != ':'))
+      {
+         return null;
+      }
+
+      int year = digits(value, 0, 4);
+      if (year < 1)
+      {
+         return null;
+      }
+
+      try
+      {
+         // Out of range components, and the -1 which digits returns for a non-digit, all throw here.
+         return LocalDateTime.of(year, digits(value, 5, 2), digits(value, 8, 2),
+            length > 10 ? digits(value, 11, 2) : 0,
+            length > 10 ? digits(value, 14, 2) : 0,
+            length == 19 ? digits(value, 17, 2) : 0);
+      }
+
+      catch (DateTimeException ex)
+      {
+         return null;
+      }
+   }
+
+   /**
+    * The number held by the given digits, or -1 where any of them is not a digit.
+    *
+    * @param value string value
+    * @param offset offset of the first digit
+    * @param length number of digits
+    * @return number, or -1
+    */
+   private static int digits(String value, int offset, int length)
+   {
+      int result = 0;
+      for (int index = offset; index < offset + length; index++)
+      {
+         int digit = value.charAt(index) - '0';
+         if (digit < 0 || digit > 9)
+         {
+            return -1;
+         }
+         result = (result * 10) + digit;
+      }
+      return result;
    }
 
    private final boolean m_ignoreErrors;

--- a/src/test/java/org/mpxj/junit/ReaderTokenizerTest.java
+++ b/src/test/java/org/mpxj/junit/ReaderTokenizerTest.java
@@ -1,0 +1,214 @@
+/*
+ * file:       ReaderTokenizerTest.java
+ * author:     Petr Janeček
+ * date:       2026-07-29
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+package org.mpxj.junit;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mpxj.common.ReaderTokenizer;
+import org.mpxj.common.Tokenizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * ReaderTokenizer tests, covering the block buffer it reads characters through.
+ */
+public class ReaderTokenizerTest
+{
+   /**
+    * Test that empty input yields no tokens.
+    *
+    * @throws IOException if the tokenizer cannot read
+    */
+   @Test public void emptyInput() throws IOException
+   {
+      assertEquals(Collections.emptyList(), tokenize(""));
+   }
+
+   /**
+    * Test that reading past the end keeps reporting the end.
+    *
+    * @throws IOException if the tokenizer cannot read
+    */
+   @Test public void repeatedReadsPastTheEnd() throws IOException
+   {
+      Tokenizer tokenizer = tokenizerFor("a");
+      assertEquals(Tokenizer.TT_WORD, tokenizer.nextToken());
+      assertEquals("a", tokenizer.getToken());
+
+      for (int index = 0; index < 3; index++)
+      {
+         assertEquals(Tokenizer.TT_EOF, tokenizer.nextToken());
+      }
+   }
+
+   /**
+    * Test input shorter than, equal to and longer than the read buffer, with fields of
+    * increasing width so that a token straddles each buffer boundary.
+    *
+    * @throws IOException if the tokenizer cannot read
+    */
+   @Test public void inputSpanningTheReadBuffer() throws IOException
+   {
+      int[] lengths = new int[]
+      {
+         1,
+         8191,
+         8192,
+         8193,
+         24576
+      };
+
+      for (int length : lengths)
+      {
+         List<String> expected = fieldsTotalling(length);
+         assertEquals(expected, tokenize(join(expected, '\t')), "length " + length);
+      }
+   }
+
+   /**
+    * Test that a line ending is still recognised when it falls on a buffer boundary.
+    *
+    * @throws IOException if the tokenizer cannot read
+    */
+   @Test public void lineEndingOnTheBufferBoundary() throws IOException
+   {
+      String field = repeat('x', 8191);
+
+      Tokenizer tokenizer = tokenizerFor(field + "\r\na\tb");
+      assertEquals(Tokenizer.TT_WORD, tokenizer.nextToken());
+      assertEquals(field, tokenizer.getToken());
+      assertEquals(Tokenizer.TT_EOL, tokenizer.nextToken());
+      assertEquals(Arrays.asList("a", "b"), remainingWords(tokenizer));
+   }
+
+   /**
+    * Tab-separated fields of doubling width whose joined length is as given.
+    *
+    * @param length total length of the joined fields
+    * @return field values
+    */
+   private List<String> fieldsTotalling(int length)
+   {
+      List<String> fields = new ArrayList<>();
+      int remaining = length;
+      int width = 1;
+      while (remaining > 0)
+      {
+         int size = Math.min(width, remaining);
+         fields.add(repeat('a', size));
+         remaining -= size;
+         if (remaining > 0)
+         {
+            remaining--; // the delimiter between this field and the next
+         }
+         width = (width * 2) + 1;
+      }
+      return fields;
+   }
+
+   /**
+    * Every word token the tokenizer reads from the given text.
+    *
+    * @param text text to tokenize
+    * @return token values
+    * @throws IOException if the tokenizer cannot read
+    */
+   private List<String> tokenize(String text) throws IOException
+   {
+      return remainingWords(tokenizerFor(text));
+   }
+
+   /**
+    * Every word token left in the given tokenizer.
+    *
+    * @param tokenizer tokenizer to drain
+    * @return token values
+    * @throws IOException if the tokenizer cannot read
+    */
+   private List<String> remainingWords(Tokenizer tokenizer) throws IOException
+   {
+      List<String> tokens = new ArrayList<>();
+      while (tokenizer.nextToken() != Tokenizer.TT_EOF)
+      {
+         if (tokenizer.getType() == Tokenizer.TT_WORD)
+         {
+            tokens.add(tokenizer.getToken());
+         }
+      }
+      return tokens;
+   }
+
+   /**
+    * A tab-delimited tokenizer over the given text.
+    *
+    * @param text text to tokenize
+    * @return tokenizer instance
+    */
+   private Tokenizer tokenizerFor(String text)
+   {
+      Tokenizer tokenizer = new ReaderTokenizer(new StringReader(text));
+      tokenizer.setDelimiter('\t');
+      return tokenizer;
+   }
+
+   /**
+    * The given values joined by the given delimiter.
+    *
+    * @param values values to join
+    * @param delimiter delimiter to join them with
+    * @return joined value
+    */
+   private String join(List<String> values, char delimiter)
+   {
+      StringBuilder result = new StringBuilder();
+      for (String value : values)
+      {
+         if (result.length() != 0)
+         {
+            result.append(delimiter);
+         }
+         result.append(value);
+      }
+      return result.toString();
+   }
+
+   /**
+    * A string of the given character repeated.
+    *
+    * @param character character to repeat
+    * @param count number of repetitions
+    * @return repeated value
+    */
+   private String repeat(char character, int count)
+   {
+      char[] characters = new char[count];
+      Arrays.fill(characters, character);
+      return new String(characters);
+   }
+}

--- a/src/test/java/org/mpxj/junit/SumTest.java
+++ b/src/test/java/org/mpxj/junit/SumTest.java
@@ -1,0 +1,123 @@
+/*
+ * file:       SumTest.java
+ * author:     Petr Janeček
+ * date:       2026-07-29
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+package org.mpxj.junit;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.mpxj.common.NumberHelper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Tests for NumberHelper.sumAsDouble, which sums costs.
+ *
+ * This uses the JDK's compensated summation, whose last bits are not the same on every JDK: both
+ * DoubleStream.sum and DoubleSummaryStatistics add the compensation on Java 8 and subtract it on
+ * later versions. So these tests pin the behaviour callers rely on, and the agreement between the
+ * two JDK routes, rather than hard coding sums which would only hold on one runtime.
+ */
+public class SumTest
+{
+   /**
+    * Test that summing matches the stream the callers previously used, whichever JDK this is.
+    */
+   @Test public void matchesDoubleStreamSum()
+   {
+      double[][] cases = new double[][]
+      {
+         {
+            52873.71,
+            82254.83
+         },
+         {
+            12892.19,
+            56542.29
+         },
+         {
+            44290.35,
+            5978.17,
+            69428.46
+         },
+         {
+            0.1,
+            0.2
+         },
+         {
+            1e16,
+            1.0,
+            -1e16
+         }
+      };
+
+      for (double[] values : cases)
+      {
+         Number[] boxed = new Number[values.length];
+         for (int index = 0; index < values.length; index++)
+         {
+            boxed[index] = Double.valueOf(values[index]);
+         }
+
+         assertEquals(Double.valueOf(Arrays.stream(values).sum()), NumberHelper.sumAsDouble(boxed), Arrays.toString(values));
+      }
+   }
+
+   /**
+    * Test that exactly representable values sum exactly, and that no values sum to zero.
+    */
+   @Test public void exactValuesSumExactly()
+   {
+      assertEquals(Double.valueOf(0.75), NumberHelper.sumAsDouble(Double.valueOf(0.5), Double.valueOf(0.25)));
+      assertEquals(Double.valueOf(0), NumberHelper.sumAsDouble(Double.valueOf(1.5), Double.valueOf(-1.5)));
+      assertEquals(Double.valueOf(0), NumberHelper.sumAsDouble());
+   }
+
+   /**
+    * Test that a null value counts as zero, and that a zero result is a positive zero. Double.equals
+    * compares bits, so a negative zero would not be equal to the zero callers expect.
+    */
+   @Test public void nullValuesCountAsZero()
+   {
+      assertEquals(Double.valueOf(0), NumberHelper.sumAsDouble((Number) null, null));
+      assertEquals(Double.valueOf(7.5), NumberHelper.sumAsDouble(Double.valueOf(7.5), null));
+      assertEquals(Double.valueOf(0), NumberHelper.sumAsDouble(Double.valueOf(-0.0), Double.valueOf(-0.0)));
+   }
+
+   /**
+    * Test that same signed infinities sum to that infinity rather than NaN, which is what the
+    * simple sum held alongside the compensated one is for.
+    */
+   @Test public void sameSignedInfinitiesDoNotBecomeNaN()
+   {
+      assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), NumberHelper.sumAsDouble(Double.valueOf(Double.POSITIVE_INFINITY), Double.valueOf(Double.POSITIVE_INFINITY)));
+      assertEquals(Double.valueOf(Double.NEGATIVE_INFINITY), NumberHelper.sumAsDouble(Double.valueOf(Double.NEGATIVE_INFINITY), Double.valueOf(Double.NEGATIVE_INFINITY)));
+   }
+
+   /**
+    * Test that mixed number types are summed by their double value.
+    */
+   @Test public void mixedNumberTypesAreSummed()
+   {
+      assertEquals(Double.valueOf(6.5), NumberHelper.sumAsDouble(Integer.valueOf(2), Long.valueOf(3), Double.valueOf(1.5)));
+   }
+}

--- a/src/test/java/org/mpxj/primavera/WorkHelperTest.java
+++ b/src/test/java/org/mpxj/primavera/WorkHelperTest.java
@@ -1,0 +1,71 @@
+/*
+ * file:       WorkHelperTest.java
+ * author:     Petr Janeček
+ * date:       2026-07-29
+ */
+
+/*
+ * This library is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by the
+ * Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library; if not, write to the Free Software Foundation, Inc.,
+ * 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+package org.mpxj.primavera;
+
+import org.junit.jupiter.api.Test;
+import org.mpxj.Duration;
+import org.mpxj.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for WorkHelper.addWork. In this package because WorkHelper is package private.
+ */
+public class WorkHelperTest
+{
+   /**
+    * Test that null work values are ignored, and that the result is in hours either way.
+    */
+   @Test public void nullValuesAreIgnored()
+   {
+      Duration sum = WorkHelper.addWork(Duration.getInstance(8, TimeUnit.HOURS), null);
+      assertEquals(8.0, sum.getDuration(), 0.0);
+      assertEquals(TimeUnit.HOURS, sum.getUnits());
+
+      Duration none = WorkHelper.addWork(null, null);
+      assertNotNull(none);
+      assertEquals(0.0, none.getDuration(), 0.0);
+      assertEquals(TimeUnit.HOURS, none.getUnits());
+   }
+
+   /**
+    * Test that work is summed by its own value and the result is labelled hours, without converting
+    * between units. Recorded because the values being summed carry units of their own.
+    */
+   @Test public void valuesAreSummedWithoutConversion()
+   {
+      Duration sum = WorkHelper.addWork(Duration.getInstance(1, TimeUnit.DAYS), Duration.getInstance(2, TimeUnit.HOURS));
+      assertEquals(3.0, sum.getDuration(), 0.0);
+      assertEquals(TimeUnit.HOURS, sum.getUnits());
+   }
+
+   /**
+    * Test that same signed infinities sum to that infinity rather than NaN.
+    */
+   @Test public void sameSignedInfinitiesDoNotBecomeNaN()
+   {
+      Duration sum = WorkHelper.addWork(Duration.getInstance(Double.POSITIVE_INFINITY, TimeUnit.HOURS), Duration.getInstance(Double.POSITIVE_INFINITY, TimeUnit.HOURS));
+      assertEquals(Double.POSITIVE_INFINITY, sum.getDuration(), 0.0);
+   }
+}


### PR DESCRIPTION
Hello again!

(AI-assisted, but I keep it on a very short leash. Heavily guided and manually revised.)

I profiled some XER imports and came up with speedup ideas. Seven commits, each standalone, but all working together. The first two are alternatives to each other. Take, drop or rework any of them.

Two large XERs, steady-state parse through `UniversalProjectReader.readAll`:

|                    | time           | allocation    |
| ------------------ | -------------- | ------------- |
| 170 MB, 110k tasks | 7192 → 3395 ms | 18.2 → 3.3 GB |
| 70 MB, 50k tasks   | 3906 → 1487 ms | 9.7 → 1.7 GB  |

Each commit's row is cumulative to the ones above it. Alone, they'd likely not have such an impact.

| commit                                   | 170 MB time | 170 MB alloc | 70 MB time  | 70 MB alloc |
| ---------------------------------------- | ----------- | ------------ | ----------- | ----------- |
| stock                                    | 7192 ms     | 18.16 GB     | 3906 ms     | 9.73 GB     |
| 1. `BufferedReader` in `ReaderTokenizer` | 5955 (−17%) | 11.60 (−36%) | 3176 (−19%) | 6.33 (−35%) |
| 2. a block buffer instead — supersedes 1 | 5614 (−6%)  | 11.60 (±0)   | 2782 (−12%) | 6.33 (±0)   |
| 3. fast path for XER dates               | 4334 (−23%) | 7.02 (−39%)  | 1824 (−34%) | 2.94 (−54%) |
| 4. no stream in `getTotalTime`           | 3888 (−10%) | 4.31 (−39%)  | 1751 (−4%)  | 2.22 (−24%) |
| 5. `getWork` steps a `LocalDate`         | 3579 (−8%)  | 3.97 (−8%)   | 1610 (−8%)  | 2.13 (−4%)  |
| 6. no stream in `ActivityCode` lookup    | 3505 (−2%)  | 3.72 (−6%)   | 1645 (+2%)  | 2.06 (−3%)  |
| 7. no stream in the cost and work sums   | 3395 (−3%)  | 3.27 (−12%)  | 1487 (−10%) | 1.68 (−18%) |

1. `ReaderTokenizer` reads a character at a time. Every such call goes through `Reader` and gets a lock, allocates a `char[2]` and wraps it in a `CharBuffer`. Let's instead make buffered reads (the underlying stream is buffered, does not matter here). Use the JDK-provided `BufferedReader`.

2. `BufferedReader` is still not the best probably because it is synchronized. Use a manual buffer and a simple index instead, it's a little faster and the code is not that difficult.

    `ReaderTokenizer` now reads ahead of the current token, so the `Reader` it is given must not be shared with anything reading from it afterwards. That is the only behaviour change in the branch.

    FYI I first tried doing this to `InputStreamTokenizer`, but `MPXReader` reads the file-creation record with it and then switches to a `ReaderTokenizer` over the same stream, so buffering it would read past the handoff.

3. The five nested optional sections in `yyyy-M-dd[ HH[:][.]mm[[:][.]ss]]` copy the parse context on the way in. The fast path handles the three shapes P6 actually writes (?!) and falls back to the formatter for everything else, so the accepted formats don't change. I tested this on all the files I have available and it occasionally goes to the fallback, but generally improves the situation substantially.

4. Wow, this one surprised me when I saw it in the profile. Huge allocation hog.
5. Minor, but counts.
6. ... no time improvement, but helps on allocations
7. `DoubleSummaryStatistics` rather than a hand-written loop, on purpose. I wrote the compensated summation out by hand first and it was wrong: Java 8 *adds* the compensation where later versions *subtract* it, so a manual loop would be correct on one JDK and wrong on another. Delegating tracks whichever the JDK does, and mpxj still targets 1.8. Also interestingly the class looks like it does a lot more than just sum, but the compiler is smart enough to remove the dead code and escape analysis works like magic here. A `DoubleSummaryStatistics` instance has the same performance as a manual loop.

---

JDK 25, Apple M3 Pro. Repeat runs of the same build vary a few percent; stock varies most, being the one that allocates 18 GB.